### PR TITLE
Refactor dev requirements out of `setup.py`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,8 @@ jobs:
         run: |
           python3 -m pip install --upgrade pip
           pip3 install --upgrade coveralls
-          pip3 install -e .[dev]
+          pip3 install -e .
+          pip3 install -r requirements-dev.txt
 
       - name: Run all checks
         run: |

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -54,7 +54,8 @@ Run in your virtual environment:
 
 .. code-block::
 
-    pip3 install --editable .[dev]
+    pip3 install --editable .
+    pip3 install -r requirements-dev.txt
 
 Now you can execute the checks (from the repository root):
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,8 @@
+black==22.10.0
+mypy==0.982
+pylint==2.15.4
+coverage>=6.5.0,<7
+pyinstaller>=5<6
+twine
+aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@e63c0c9#egg=aas-core-meta
+aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@4a4695c#egg=aas-core-codegen

--- a/setup.py
+++ b/setup.py
@@ -39,20 +39,6 @@ setup(
     keywords="asset administration shell sdk industry 4.0 industrie i4.0 industry iot iiot",
     packages=find_packages(exclude=["tests", "continuous_integration", "dev_scripts"]),
     install_requires=[] if sys.version_info >= (3, 8) else ["typing_extensions"],
-    # fmt: off
-    extras_require={
-        "dev": [
-            "black==22.10.0",
-            "mypy==0.982",
-            "pylint==2.15.4",
-            "coverage>=6.5.0,<7",
-            "pyinstaller>=5<6",
-            "twine",
-            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@e63c0c9#egg=aas-core-meta",
-            "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@4a4695c#egg=aas-core-codegen",
-        ]
-    },
-    # fmt: on
     py_modules=["aas_core3_rc02"],
     package_data={"aas_core3_rc02": ["py.typed"]},
     data_files=[(".", ["LICENSE", "README.rst"])],


### PR DESCRIPTION
We move the development requirements to a separate file since PyPI does not allow us to publish packages with dependencies pointing to a GitHub repository.