### PR TITLE
Update to meta 3ffe727 and codegen 46ddb38f

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,5 +4,5 @@ pylint==2.15.4
 coverage>=6.5.0,<7
 pyinstaller>=5<6
 twine
-aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@e63c0c9#egg=aas-core-meta
-aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@4a4695c#egg=aas-core-codegen
+aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@3ffe727#egg=aas-core-meta
+aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@46ddb38f#egg=aas-core-codegen


### PR DESCRIPTION
We update to [aas-core-meta 3ffe727] and [aas-core-codegen 46ddb38f]. This update is necessary as aas-core-meta and codegen need to be updated in sync since we changed the parsing of the references in the meta-model.

[aas-core-codegen 46ddb38f]: https://github.com/aas-core-works/aas-core-codegen/commit/46ddb38f
[aas-core-meta 3ffe727]: https://github.com/aas-core-works/aas-core-meta/commit/3ffe727