### PR TITLE
Find test cases recursively in test data

### DIFF
--- a/aas_core3_rc02/verification.py
+++ b/aas_core3_rc02/verification.py
@@ -180,7 +180,7 @@ def is_xs_date_time_stamp_utc(value: str) -> bool:
     Check that :paramref:`value` is a ``xs:dateTimeStamp`` with
     the time zone set to UTC.
     """
-    if matches_xs_date_time_stamp_utc(value) is None:
+    if matches_xs_date_time_stamp_utc(value) is False:
         return False
 
     date, _ = value.split("T")
@@ -1270,6 +1270,9 @@ _DAYS_IN_MONTH: Mapping[int, int] = {
 }
 
 
+_DATE_PREFIX_RE = re.compile(r"^(-?[0-9]+)-([0-9]{2})-([0-9]{2})")
+
+
 def is_xs_date(value: str) -> bool:
     """
     Check that :paramref:`value` is a valid ``xs:date``.
@@ -1277,13 +1280,21 @@ def is_xs_date(value: str) -> bool:
     We can not use :py:func:`datetime.date.strptime` as it does not
     handle years below 1000 correctly on Windows (*e.g.*, ``-999-01-01``).
     """
-    if matches_xs_date(value) is None:
+    if matches_xs_date(value) is False:
         return False
 
-    year_str, month_str, day_str = value.split("-")
-    year = int(year_str)
-    month = int(month_str)
-    day = int(day_str)
+    # NOTE (mristin, 2022-10-30):
+    # We need to match the prefix as zone offsets are allowed in the dates. Optimally,
+    # we would re-use the pattern matching from :py:func`matches_xs_date`, but this
+    # would make the code generation and constraint inference for schemas much more
+    # difficult. Hence, we sacrifice the efficiency a bit for the clearer code & code
+    # generation.
+    match = _DATE_PREFIX_RE.match(value)
+    assert match is not None
+
+    year = int(match.group(1))
+    month = int(match.group(2))
+    day = int(match.group(3))
 
     # We do not accept year zero,
     # see the note at: https://www.w3.org/TR/xmlschema-2/#dateTime
@@ -1317,7 +1328,7 @@ def is_xs_date_time(value: str) -> bool:
     We can not use :py:func:`datetime.datetime.strptime` as it does not
     handle years below 1000 correctly on Windows (*e.g.*, ``-999-01-01``).
     """
-    if matches_xs_date_time(value) is None:
+    if matches_xs_date_time(value) is False:
         return False
 
     date, _ = value.split("T")
@@ -1331,7 +1342,7 @@ def is_xs_date_time_stamp(value: str) -> bool:
     We can not use :py:func:`datetime.datetime.strptime` as it does not
     handle years below 1000 correctly on Windows (*e.g.*, ``-999-01-01``).
     """
-    if matches_xs_date_time_stamp(value) is None:
+    if matches_xs_date_time_stamp(value) is False:
         return False
 
     date, _ = value.split("T")
@@ -1344,7 +1355,7 @@ def is_xs_double(value: str) -> bool:
     # ``float(.)`` is too permissive. For example,
     # it accepts "nan" although only "NaN" is valid.
     # See: https://www.w3.org/TR/xmlschema-2/#double
-    if matches_xs_double(value) is None:
+    if matches_xs_double(value) is False:
         return False
 
     converted = float(value)
@@ -1369,7 +1380,20 @@ def is_xs_float(value: str) -> bool:
     # ``float(.)`` is too permissive. For example,
     # it accepts "nan" although only "NaN" is valid.
     # See: https://www.w3.org/TR/xmlschema-2/#double
-    if matches_xs_float(value) is None:
+    if matches_xs_float(value) is False:
+        return False
+
+    converted = float(value)
+
+    # Check that the value is either "INF" or "-INF".
+    # Otherwise, the value is a decimal which is too big
+    # to be represented as a single-precision floating point
+    # number.
+    #
+    # Python simply rounds up/down to ``INF`` and ``-INF``,
+    # respectively, if the number is too large.
+    # For example: ``float("1e400") == math.inf``
+    if math.isinf(converted) and value != "INF" and value != "-INF":
         return False
 
     # Python uses double-precision floating point numbers. Since
@@ -1377,7 +1401,7 @@ def is_xs_float(value: str) -> bool:
     # see if the number is within a range of a single-precision
     # floating point numbers.
     try:
-        _ = struct.pack(">f", value)
+        _ = struct.pack(">f", converted)
     except OverflowError:
         return False
 
@@ -1386,7 +1410,7 @@ def is_xs_float(value: str) -> bool:
 
 def is_xs_g_month_day(value: str) -> bool:
     """Check that :paramref:`value` is a valid ``xs:gMonthDay``."""
-    if matches_xs_g_month_day(value) is None:
+    if matches_xs_g_month_day(value) is False:
         return False
 
     month = int(value[2:4])
@@ -1398,7 +1422,7 @@ def is_xs_g_month_day(value: str) -> bool:
 
 def is_xs_long(value: str) -> bool:
     """Check that :paramref:`value` is a valid ``xs:long``."""
-    if matches_xs_long(value) is None:
+    if matches_xs_long(value) is False:
         return False
 
     converted = int(value)
@@ -1407,7 +1431,7 @@ def is_xs_long(value: str) -> bool:
 
 def is_xs_int(value: str) -> bool:
     """Check that :paramref:`value` is a valid ``xs:int``."""
-    if matches_xs_int(value) is None:
+    if matches_xs_int(value) is False:
         return False
 
     converted = int(value)
@@ -1416,7 +1440,7 @@ def is_xs_int(value: str) -> bool:
 
 def is_xs_short(value: str) -> bool:
     """Check that :paramref:`value` is a valid ``xs:short``."""
-    if matches_xs_short(value) is None:
+    if matches_xs_short(value) is False:
         return False
 
     converted = int(value)
@@ -1425,7 +1449,7 @@ def is_xs_short(value: str) -> bool:
 
 def is_xs_byte(value: str) -> bool:
     """Check that :paramref:`value` is a valid ``xs:byte``."""
-    if matches_xs_byte(value) is None:
+    if matches_xs_byte(value) is False:
         return False
 
     converted = int(value)
@@ -1434,7 +1458,7 @@ def is_xs_byte(value: str) -> bool:
 
 def is_xs_unsigned_long(value: str) -> bool:
     """Check that :paramref:`value` is a valid ``xs:unsignedLong``."""
-    if matches_xs_unsigned_long(value) is None:
+    if matches_xs_unsigned_long(value) is False:
         return False
 
     converted = int(value)
@@ -1443,7 +1467,7 @@ def is_xs_unsigned_long(value: str) -> bool:
 
 def is_xs_unsigned_int(value: str) -> bool:
     """Check that :paramref:`value` is a valid ``xs:unsignedInt``."""
-    if matches_xs_unsigned_int(value) is None:
+    if matches_xs_unsigned_int(value) is False:
         return False
 
     converted = int(value)
@@ -1452,7 +1476,7 @@ def is_xs_unsigned_int(value: str) -> bool:
 
 def is_xs_unsigned_short(value: str) -> bool:
     """Check that :paramref:`value` is a valid ``xs:unsignedShort``."""
-    if matches_xs_unsigned_short(value) is None:
+    if matches_xs_unsigned_short(value) is False:
         return False
 
     converted = int(value)
@@ -1461,7 +1485,7 @@ def is_xs_unsigned_short(value: str) -> bool:
 
 def is_xs_unsigned_byte(value: str) -> bool:
     """Check that :paramref:`value` is a valid ``xs:unsignedByte``."""
-    if matches_xs_unsigned_byte(value) is None:
+    if matches_xs_unsigned_byte(value) is False:
         return False
 
     converted = int(value)

--- a/aas_core3_rc02/xmlization.py
+++ b/aas_core3_rc02/xmlization.py
@@ -22456,7 +22456,7 @@ class _Serializer(aas_types.AbstractVisitor):
         # a dictionary, and on another snippet which called three ``.replace()``.
         # The code with ``.replace()`` was an order of magnitude faster on our computers.
         self.stream.write(
-            text.replace("&", "&amp").replace("<", "&lt;").replace(">", "&gt;")
+            text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
         )
 
     def _write_end_element(self, name: str) -> None:

--- a/dev_scripts/generate_test_for_jsonization_of_concrete_classes.py
+++ b/dev_scripts/generate_test_for_jsonization_of_concrete_classes.py
@@ -55,7 +55,7 @@ def test_ok(self) -> None:
 {IIII}/ "SelfContained"
 {IIII}/ "Expected"
 {IIII}/ {cls_name_json_literal}
-{II}).glob("*.json")
+{II}).glob("**/*.json")
 {I})
 
 {I}for path in paths:
@@ -121,7 +121,7 @@ def test_deserialization_failures(self) -> None:
 {III}# and this ``cause``.
 {III}continue
 
-{II}for path in sorted(base_dir.glob("*.json")):
+{II}for path in sorted(base_dir.glob("**/*.json")):
 {III}with path.open("rt") as fid:
 {IIII}jsonable = json.load(fid)
 
@@ -162,7 +162,7 @@ def test_verification_failures(self) -> None:
 {III}# and this ``cause``.
 {III}continue
 
-{II}for path in sorted(base_dir.glob("*.json")):
+{II}for path in sorted(base_dir.glob("**/*.json")):
 {III}with path.open("rt") as fid:
 {IIII}jsonable = json.load(fid)
 
@@ -243,7 +243,7 @@ def test_ok(self) -> None:
 {IIII}/ "ContainedInEnvironment"
 {IIII}/ "Expected"
 {IIII}/ {cls_name_json_literal}
-{II}).glob("*.json")
+{II}).glob("**/*.json")
 {I})
 
 {I}for path in paths:
@@ -309,7 +309,7 @@ def test_deserialization_failures(self) -> None:
 {III}# and this ``cause``.
 {III}continue
 
-{II}for path in sorted(base_dir.glob("*.json")):
+{II}for path in sorted(base_dir.glob("**/*.json")):
 {III}with path.open("rt") as fid:
 {IIII}jsonable = json.load(fid)
 
@@ -350,7 +350,7 @@ def test_verification_failures(self) -> None:
 {III}# and this ``cause``.
 {III}continue
 
-{II}for path in sorted(base_dir.glob("*.json")):
+{II}for path in sorted(base_dir.glob("**/*.json")):
 {III}with path.open("rt") as fid:
 {IIII}jsonable = json.load(fid)
 

--- a/dev_scripts/generate_test_for_xmlization_of_concrete_classes.py
+++ b/dev_scripts/generate_test_for_xmlization_of_concrete_classes.py
@@ -81,7 +81,7 @@ def test_ok(self) -> None:
 {IIII}/ {container_kind_literal}
 {IIII}/ "Expected"
 {IIII}/ {xml_class_name_literal}
-{II}).glob("*.xml")
+{II}).glob("**/*.xml")
 {I})
 
 {I}for path in paths:
@@ -135,7 +135,7 @@ def test_deserialization_failures(self) -> None:
 {III}# and this ``cause``.
 {III}continue
 
-{II}for path in sorted(base_dir.glob("*.xml")):
+{II}for path in sorted(base_dir.glob("**/*.xml")):
 {III}observed_exception: Optional[
 {IIII}aas_xmlization.DeserializationException
 {III}] = None
@@ -175,7 +175,7 @@ def test_verification_failures(self) -> None:
 {III}# and this ``cause``.
 {III}continue
 
-{II}for path in sorted(base_dir.glob("*.xml")):
+{II}for path in sorted(base_dir.glob("**/*.xml")):
 {III}try:
 {IIII}{target_variable} = aas_xmlization.{from_str}(
 {IIIII}path.read_text(encoding='utf-8')
@@ -212,7 +212,7 @@ def test_different_input_forms_give_equal_outcomes(self) -> None:
 {IIII}/ {container_kind_literal}
 {IIII}/ "Expected"
 {IIII}/ {xml_class_name_literal}
-{II}).glob("*.xml")
+{II}).glob("**/*.xml")
 {I})
 
 {I}for path in paths:

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Any_URI/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Any_URI/negatively_fuzzed_01.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Any_URI/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Any_URI/negatively_fuzzed_02.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Any_URI/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Any_URI/negatively_fuzzed_03.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Any_URI/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Any_URI/negatively_fuzzed_04.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Any_URI/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Any_URI/negatively_fuzzed_05.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Any_URI/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Any_URI/negatively_fuzzed_06.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Any_URI/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Any_URI/negatively_fuzzed_07.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Any_URI/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Any_URI/negatively_fuzzed_08.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Any_URI/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Any_URI/negatively_fuzzed_09.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Any_URI/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Any_URI/negatively_fuzzed_10.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Any_URI/percentage_followed_by_non_two_hexadecimal_digits.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Any_URI/percentage_followed_by_non_two_hexadecimal_digits.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Any_URI/too_many_fragments.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Any_URI/too_many_fragments.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Base_64_binary/an_odd_number_of_characters_is_not_valid.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Base_64_binary/an_odd_number_of_characters_is_not_valid.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Base_64_binary/equals_signs_may_only_appear_at_the_end.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Base_64_binary/equals_signs_may_only_appear_at_the_end.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Base_64_binary/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Base_64_binary/negatively_fuzzed_01.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Base_64_binary/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Base_64_binary/negatively_fuzzed_02.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Base_64_binary/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Base_64_binary/negatively_fuzzed_03.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Base_64_binary/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Base_64_binary/negatively_fuzzed_04.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Base_64_binary/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Base_64_binary/negatively_fuzzed_05.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Base_64_binary/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Base_64_binary/negatively_fuzzed_06.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Base_64_binary/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Base_64_binary/negatively_fuzzed_07.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Base_64_binary/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Base_64_binary/negatively_fuzzed_08.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Base_64_binary/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Base_64_binary/negatively_fuzzed_09.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Base_64_binary/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Base_64_binary/negatively_fuzzed_10.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Boolean/false_as_number_with_leading_zeros.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Boolean/false_as_number_with_leading_zeros.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Boolean/false_in_camelcase.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Boolean/false_in_camelcase.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Boolean/false_in_uppercase.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Boolean/false_in_uppercase.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Boolean/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Boolean/negatively_fuzzed_01.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Boolean/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Boolean/negatively_fuzzed_02.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Boolean/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Boolean/negatively_fuzzed_03.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Boolean/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Boolean/negatively_fuzzed_04.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Boolean/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Boolean/negatively_fuzzed_05.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Boolean/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Boolean/negatively_fuzzed_06.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Boolean/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Boolean/negatively_fuzzed_07.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Boolean/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Boolean/negatively_fuzzed_08.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Boolean/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Boolean/negatively_fuzzed_09.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Boolean/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Boolean/negatively_fuzzed_10.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Boolean/true_as_number_with_leading_zeros.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Boolean/true_as_number_with_leading_zeros.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Boolean/true_in_camelcase.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Boolean/true_in_camelcase.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Boolean/true_in_uppercase.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Boolean/true_in_uppercase.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Byte/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Byte/decimal.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Byte/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Byte/empty.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Byte/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Byte/free_form_text.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Byte/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Byte/mathematical_formula.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Byte/max_plus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Byte/max_plus_one.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Byte/min_minus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Byte/min_minus_one.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Byte/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Byte/scientific.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/date_time_with_UTC.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/date_time_with_UTC.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/date_time_with_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/date_time_with_offset.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/date_time_without_zone.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/date_time_without_zone.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/date_with_invalid_negative_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/date_with_invalid_negative_offset.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/date_with_invalid_positive_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/date_with_invalid_positive_offset.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/date_with_seconds_in_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/date_with_seconds_in_offset.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/empty.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/non_existing_february_29th.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/non_existing_february_29th.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/date.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/date.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/date_time_with_invalid_negative_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/date_time_with_invalid_negative_offset.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/date_time_with_invalid_positive_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/date_time_with_invalid_positive_offset.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/date_time_with_seconds_in_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/date_time_with_seconds_in_offset.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/date_time_with_unexpected_prefix.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/date_time_with_unexpected_prefix.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/date_time_with_unexpected_suffix.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/date_time_with_unexpected_suffix.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/date_with_time_zone.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/date_with_time_zone.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/empty.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/non_existing_february_29th.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/non_existing_february_29th.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/without_minutes.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/without_minutes.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/without_seconds.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/without_seconds.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/date.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/date.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/date_time_stamp_with_invalid_negative_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/date_time_stamp_with_invalid_negative_offset.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/date_time_stamp_with_invalid_positive_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/date_time_stamp_with_invalid_positive_offset.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/date_time_stamp_with_seconds_in_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/date_time_stamp_with_seconds_in_offset.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/date_time_stamp_with_unexpected_prefix.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/date_time_stamp_with_unexpected_prefix.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/date_time_stamp_with_unexpected_suffix.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/date_time_stamp_with_unexpected_suffix.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/date_time_without_zone.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/date_time_without_zone.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/date_with_time_zone.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/date_with_time_zone.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/empty.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/non_existing_february_29th.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/non_existing_february_29th.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/without_minutes.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/without_minutes.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/without_seconds.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/without_seconds.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Day_time_duration/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Day_time_duration/empty.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Day_time_duration/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Day_time_duration/free_form_text.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Day_time_duration/month.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Day_time_duration/month.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Day_time_duration/negative_days.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Day_time_duration/negative_days.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Day_time_duration/year.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Day_time_duration/year.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Decimal/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Decimal/empty.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Decimal/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Decimal/free_form_text.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Double/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Double/empty.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Double/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Double/free_form_text.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Double/inf_case_matters.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Double/inf_case_matters.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Double/nan_case_matters.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Double/nan_case_matters.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Double/no_fraction_in_scientific_notation.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Double/no_fraction_in_scientific_notation.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Double/plus_inf.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Double/plus_inf.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Double/too_large.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Double/too_large.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Duration/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Duration/empty.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Duration/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Duration/free_form_text.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Duration/integer.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Duration/integer.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Duration/leading_P_missing.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Duration/leading_P_missing.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Duration/negative_years.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Duration/negative_years.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Duration/positive_year_negative_months.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Duration/positive_year_negative_months.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Duration/separator_T_missing.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Duration/separator_T_missing.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Duration/the_order_matters.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Duration/the_order_matters.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Float/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Float/empty.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Float/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Float/free_form_text.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Float/inf_case_matters.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Float/inf_case_matters.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Float/nan_case_matters.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Float/nan_case_matters.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Float/no_fraction_in_scientific_notation.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Float/no_fraction_in_scientific_notation.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Float/plus_inf.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Float/plus_inf.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Float/too_large.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Float/too_large.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_day/day_outside_of_range.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_day/day_outside_of_range.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_day/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_day/empty.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_day/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_day/free_form_text.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_day/invalid_negative_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_day/invalid_negative_offset.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_day/invalid_offset_with_seconds.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_day/invalid_offset_with_seconds.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_day/invalid_positive_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_day/invalid_positive_offset.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_day/missing_leading_dashes.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_day/missing_leading_dashes.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_day/missing_leading_digit.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_day/missing_leading_digit.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_day/unexpected_suffix.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_day/unexpected_suffix.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_month/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_month/empty.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_month/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_month/free_form_text.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_month/invalid_negative_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_month/invalid_negative_offset.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_month/invalid_offset_with_seconds.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_month/invalid_offset_with_seconds.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_month/invalid_positive_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_month/invalid_positive_offset.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_month/missing_leading_dashes.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_month/missing_leading_dashes.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_month/missing_leading_digit.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_month/missing_leading_digit.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_month/month_outside_of_range.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_month/month_outside_of_range.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_month/unexpected_prefix_and_suffix.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_month/unexpected_prefix_and_suffix.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_month_day/day_outside_of_range.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_month_day/day_outside_of_range.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_month_day/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_month_day/empty.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_month_day/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_month_day/free_form_text.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_month_day/invalid_negative_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_month_day/invalid_negative_offset.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_month_day/invalid_offset_with_seconds.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_month_day/invalid_offset_with_seconds.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_month_day/invalid_positive_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_month_day/invalid_positive_offset.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_month_day/missing_leading_dashes.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_month_day/missing_leading_dashes.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_month_day/missing_leading_digit.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_month_day/missing_leading_digit.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_month_day/non_existing_april_31st.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_month_day/non_existing_april_31st.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_month_day/unexpected_prefix_and_suffix.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_month_day/unexpected_prefix_and_suffix.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_year/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_year/empty.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_year/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_year/free_form_text.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_year/invalid_negative_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_year/invalid_negative_offset.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_year/invalid_offset_with_seconds.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_year/invalid_offset_with_seconds.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_year/invalid_positive_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_year/invalid_positive_offset.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_year/missing_century.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_year/missing_century.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_year/unexpected_month.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_year/unexpected_month.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_year_month/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_year_month/empty.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_year_month/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_year_month/free_form_text.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_year_month/invalid_negative_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_year_month/invalid_negative_offset.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_year_month/invalid_offset_with_seconds.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_year_month/invalid_offset_with_seconds.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_year_month/invalid_positive_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_year_month/invalid_positive_offset.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_year_month/missing_century.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_year_month/missing_century.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_year_month/missing_month.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_year_month/missing_month.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_year_month/month_out_of_range.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/G_year_month/month_out_of_range.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Hex_binary/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Hex_binary/free_form_text.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Hex_binary/odd_number_of_digits.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Hex_binary/odd_number_of_digits.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Hex_binary/single_digit.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Hex_binary/single_digit.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Int/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Int/decimal.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Int/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Int/empty.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Int/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Int/free_form_text.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Int/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Int/mathematical_formula.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Int/max_plus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Int/max_plus_one.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Int/min_minus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Int/min_minus_one.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Int/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Int/scientific.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Integer/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Integer/decimal.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Integer/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Integer/empty.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Integer/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Integer/free_form_text.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Integer/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Integer/mathematical_formula.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Integer/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Integer/scientific.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Long/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Long/decimal.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Long/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Long/empty.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Long/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Long/free_form_text.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Long/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Long/mathematical_formula.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Long/max_plus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Long/max_plus_one.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Long/min_minus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Long/min_minus_one.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Long/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Long/scientific.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Negative_integer/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Negative_integer/decimal.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Negative_integer/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Negative_integer/empty.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Negative_integer/explicitly_positive.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Negative_integer/explicitly_positive.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Negative_integer/explicitly_positive_zero.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Negative_integer/explicitly_positive_zero.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Negative_integer/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Negative_integer/free_form_text.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Negative_integer/implicitly_positive.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Negative_integer/implicitly_positive.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Negative_integer/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Negative_integer/mathematical_formula.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Negative_integer/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Negative_integer/scientific.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Negative_integer/zero.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Negative_integer/zero.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Negative_integer/zero_prefixed_with_zeros.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Negative_integer/zero_prefixed_with_zeros.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Non_negative_integer/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Non_negative_integer/decimal.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Non_negative_integer/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Non_negative_integer/empty.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Non_negative_integer/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Non_negative_integer/free_form_text.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Non_negative_integer/negative.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Non_negative_integer/negative.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Non_positive_integer/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Non_positive_integer/decimal.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Non_positive_integer/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Non_positive_integer/empty.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Non_positive_integer/explicitly_positive.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Non_positive_integer/explicitly_positive.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Non_positive_integer/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Non_positive_integer/free_form_text.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Non_positive_integer/implicitly_positive.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Non_positive_integer/implicitly_positive.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Non_positive_integer/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Non_positive_integer/mathematical_formula.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Non_positive_integer/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Non_positive_integer/scientific.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Positive_integer/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Positive_integer/decimal.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Positive_integer/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Positive_integer/empty.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Positive_integer/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Positive_integer/free_form_text.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Positive_integer/negative.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Positive_integer/negative.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Positive_integer/zero.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Positive_integer/zero.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Positive_integer/zero_prefixed_with_zeros.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Positive_integer/zero_prefixed_with_zeros.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Short/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Short/decimal.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Short/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Short/empty.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Short/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Short/free_form_text.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Short/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Short/mathematical_formula.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Short/max_plus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Short/max_plus_one.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Short/min_minus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Short/min_minus_one.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Short/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Short/scientific.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/String/NUL_as_utf16.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/String/NUL_as_utf16.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/String/NUL_as_utf32.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/String/NUL_as_utf32.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/String/NUL_as_x.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/String/NUL_as_x.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/String/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/String/negatively_fuzzed_01.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/String/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/String/negatively_fuzzed_02.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/String/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/String/negatively_fuzzed_03.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/String/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/String/negatively_fuzzed_04.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/String/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/String/negatively_fuzzed_05.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/String/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/String/negatively_fuzzed_06.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/String/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/String/negatively_fuzzed_07.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/String/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/String/negatively_fuzzed_08.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/String/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/String/negatively_fuzzed_09.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/String/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/String/negatively_fuzzed_10.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Time/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Time/empty.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Time/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Time/free_form_text.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Time/hour_out_of_range.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Time/hour_out_of_range.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Time/invalid_negative_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Time/invalid_negative_offset.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Time/invalid_offset_with_seconds.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Time/invalid_offset_with_seconds.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Time/invalid_positive_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Time/invalid_positive_offset.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Time/minute_out_of_range.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Time/minute_out_of_range.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Time/missing_padded_zeros.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Time/missing_padded_zeros.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Time/missing_seconds.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Time/missing_seconds.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Time/negative.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Time/negative.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Time/second_out_of_range.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Time/second_out_of_range.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_byte/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_byte/decimal.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_byte/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_byte/empty.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_byte/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_byte/free_form_text.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_byte/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_byte/mathematical_formula.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_byte/max_plus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_byte/max_plus_one.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_byte/negative.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_byte/negative.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_byte/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_byte/scientific.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_int/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_int/decimal.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_int/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_int/empty.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_int/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_int/free_form_text.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_int/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_int/mathematical_formula.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_int/max_plus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_int/max_plus_one.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_int/negative.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_int/negative.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_int/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_int/scientific.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_long/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_long/decimal.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_long/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_long/empty.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_long/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_long/free_form_text.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_long/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_long/mathematical_formula.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_long/max_plus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_long/max_plus_one.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_long/negative.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_long/negative.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_long/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_long/scientific.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_short/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_short/decimal.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_short/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_short/empty.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_short/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_short/free_form_text.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_short/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_short/mathematical_formula.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_short/max_plus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_short/max_plus_one.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_short/negative.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_short/negative.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_short/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Unsigned_short/scientific.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Year_month_duration/day.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Year_month_duration/day.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Year_month_duration/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Year_month_duration/empty.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Year_month_duration/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Year_month_duration/free_form_text.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Year_month_duration/hour_part.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Year_month_duration/hour_part.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Year_month_duration/negative_years.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Year_month_duration/negative_years.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Any_URI/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Any_URI/negatively_fuzzed_01.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Any_URI/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Any_URI/negatively_fuzzed_02.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Any_URI/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Any_URI/negatively_fuzzed_03.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Any_URI/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Any_URI/negatively_fuzzed_04.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Any_URI/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Any_URI/negatively_fuzzed_05.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Any_URI/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Any_URI/negatively_fuzzed_06.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Any_URI/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Any_URI/negatively_fuzzed_07.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Any_URI/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Any_URI/negatively_fuzzed_08.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Any_URI/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Any_URI/negatively_fuzzed_09.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Any_URI/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Any_URI/negatively_fuzzed_10.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Any_URI/percentage_followed_by_non_two_hexadecimal_digits.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Any_URI/percentage_followed_by_non_two_hexadecimal_digits.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Any_URI/too_many_fragments.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Any_URI/too_many_fragments.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Base_64_binary/an_odd_number_of_characters_is_not_valid.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Base_64_binary/an_odd_number_of_characters_is_not_valid.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Base_64_binary/equals_signs_may_only_appear_at_the_end.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Base_64_binary/equals_signs_may_only_appear_at_the_end.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Base_64_binary/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Base_64_binary/negatively_fuzzed_01.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Base_64_binary/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Base_64_binary/negatively_fuzzed_02.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Base_64_binary/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Base_64_binary/negatively_fuzzed_03.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Base_64_binary/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Base_64_binary/negatively_fuzzed_04.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Base_64_binary/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Base_64_binary/negatively_fuzzed_05.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Base_64_binary/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Base_64_binary/negatively_fuzzed_06.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Base_64_binary/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Base_64_binary/negatively_fuzzed_07.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Base_64_binary/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Base_64_binary/negatively_fuzzed_08.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Base_64_binary/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Base_64_binary/negatively_fuzzed_09.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Base_64_binary/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Base_64_binary/negatively_fuzzed_10.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Boolean/false_as_number_with_leading_zeros.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Boolean/false_as_number_with_leading_zeros.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Boolean/false_in_camelcase.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Boolean/false_in_camelcase.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Boolean/false_in_uppercase.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Boolean/false_in_uppercase.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Boolean/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Boolean/negatively_fuzzed_01.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Boolean/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Boolean/negatively_fuzzed_02.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Boolean/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Boolean/negatively_fuzzed_03.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Boolean/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Boolean/negatively_fuzzed_04.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Boolean/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Boolean/negatively_fuzzed_05.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Boolean/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Boolean/negatively_fuzzed_06.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Boolean/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Boolean/negatively_fuzzed_07.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Boolean/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Boolean/negatively_fuzzed_08.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Boolean/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Boolean/negatively_fuzzed_09.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Boolean/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Boolean/negatively_fuzzed_10.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Boolean/true_as_number_with_leading_zeros.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Boolean/true_as_number_with_leading_zeros.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Boolean/true_in_camelcase.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Boolean/true_in_camelcase.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Boolean/true_in_uppercase.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Boolean/true_in_uppercase.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Byte/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Byte/decimal.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Byte/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Byte/empty.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Byte/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Byte/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Byte/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Byte/mathematical_formula.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Byte/max_plus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Byte/max_plus_one.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Byte/min_minus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Byte/min_minus_one.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Byte/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Byte/scientific.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/date_time_with_UTC.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/date_time_with_UTC.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/date_time_with_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/date_time_with_offset.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/date_time_without_zone.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/date_time_without_zone.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/date_with_invalid_negative_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/date_with_invalid_negative_offset.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/date_with_invalid_positive_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/date_with_invalid_positive_offset.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/date_with_seconds_in_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/date_with_seconds_in_offset.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/empty.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/non_existing_february_29th.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/non_existing_february_29th.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/date.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/date.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/date_time_with_invalid_negative_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/date_time_with_invalid_negative_offset.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/date_time_with_invalid_positive_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/date_time_with_invalid_positive_offset.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/date_time_with_seconds_in_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/date_time_with_seconds_in_offset.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/date_time_with_unexpected_prefix.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/date_time_with_unexpected_prefix.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/date_time_with_unexpected_suffix.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/date_time_with_unexpected_suffix.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/date_with_time_zone.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/date_with_time_zone.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/empty.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/non_existing_february_29th.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/non_existing_february_29th.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/without_minutes.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/without_minutes.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/without_seconds.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/without_seconds.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/date.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/date.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/date_time_stamp_with_invalid_negative_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/date_time_stamp_with_invalid_negative_offset.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/date_time_stamp_with_invalid_positive_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/date_time_stamp_with_invalid_positive_offset.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/date_time_stamp_with_seconds_in_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/date_time_stamp_with_seconds_in_offset.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/date_time_stamp_with_unexpected_prefix.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/date_time_stamp_with_unexpected_prefix.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/date_time_stamp_with_unexpected_suffix.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/date_time_stamp_with_unexpected_suffix.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/date_time_without_zone.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/date_time_without_zone.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/date_with_time_zone.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/date_with_time_zone.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/empty.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/non_existing_february_29th.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/non_existing_february_29th.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/without_minutes.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/without_minutes.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/without_seconds.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/without_seconds.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Day_time_duration/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Day_time_duration/empty.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Day_time_duration/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Day_time_duration/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Day_time_duration/month.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Day_time_duration/month.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Day_time_duration/negative_days.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Day_time_duration/negative_days.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Day_time_duration/year.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Day_time_duration/year.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Decimal/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Decimal/empty.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Decimal/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Decimal/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Double/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Double/empty.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Double/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Double/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Double/inf_case_matters.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Double/inf_case_matters.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Double/nan_case_matters.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Double/nan_case_matters.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Double/no_fraction_in_scientific_notation.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Double/no_fraction_in_scientific_notation.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Double/plus_inf.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Double/plus_inf.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Double/too_large.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Double/too_large.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Duration/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Duration/empty.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Duration/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Duration/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Duration/integer.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Duration/integer.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Duration/leading_P_missing.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Duration/leading_P_missing.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Duration/negative_years.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Duration/negative_years.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Duration/positive_year_negative_months.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Duration/positive_year_negative_months.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Duration/separator_T_missing.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Duration/separator_T_missing.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Duration/the_order_matters.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Duration/the_order_matters.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Float/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Float/empty.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Float/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Float/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Float/inf_case_matters.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Float/inf_case_matters.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Float/nan_case_matters.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Float/nan_case_matters.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Float/no_fraction_in_scientific_notation.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Float/no_fraction_in_scientific_notation.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Float/plus_inf.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Float/plus_inf.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Float/too_large.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Float/too_large.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_day/day_outside_of_range.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_day/day_outside_of_range.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_day/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_day/empty.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_day/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_day/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_day/invalid_negative_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_day/invalid_negative_offset.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_day/invalid_offset_with_seconds.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_day/invalid_offset_with_seconds.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_day/invalid_positive_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_day/invalid_positive_offset.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_day/missing_leading_dashes.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_day/missing_leading_dashes.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_day/missing_leading_digit.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_day/missing_leading_digit.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_day/unexpected_suffix.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_day/unexpected_suffix.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_month/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_month/empty.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_month/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_month/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_month/invalid_negative_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_month/invalid_negative_offset.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_month/invalid_offset_with_seconds.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_month/invalid_offset_with_seconds.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_month/invalid_positive_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_month/invalid_positive_offset.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_month/missing_leading_dashes.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_month/missing_leading_dashes.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_month/missing_leading_digit.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_month/missing_leading_digit.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_month/month_outside_of_range.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_month/month_outside_of_range.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_month/unexpected_prefix_and_suffix.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_month/unexpected_prefix_and_suffix.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_month_day/day_outside_of_range.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_month_day/day_outside_of_range.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_month_day/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_month_day/empty.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_month_day/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_month_day/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_month_day/invalid_negative_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_month_day/invalid_negative_offset.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_month_day/invalid_offset_with_seconds.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_month_day/invalid_offset_with_seconds.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_month_day/invalid_positive_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_month_day/invalid_positive_offset.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_month_day/missing_leading_dashes.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_month_day/missing_leading_dashes.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_month_day/missing_leading_digit.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_month_day/missing_leading_digit.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_month_day/non_existing_april_31st.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_month_day/non_existing_april_31st.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_month_day/unexpected_prefix_and_suffix.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_month_day/unexpected_prefix_and_suffix.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_year/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_year/empty.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_year/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_year/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_year/invalid_negative_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_year/invalid_negative_offset.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_year/invalid_offset_with_seconds.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_year/invalid_offset_with_seconds.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_year/invalid_positive_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_year/invalid_positive_offset.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_year/missing_century.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_year/missing_century.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_year/unexpected_month.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_year/unexpected_month.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_year_month/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_year_month/empty.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_year_month/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_year_month/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_year_month/invalid_negative_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_year_month/invalid_negative_offset.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_year_month/invalid_offset_with_seconds.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_year_month/invalid_offset_with_seconds.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_year_month/invalid_positive_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_year_month/invalid_positive_offset.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_year_month/missing_century.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_year_month/missing_century.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_year_month/missing_month.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_year_month/missing_month.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_year_month/month_out_of_range.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/G_year_month/month_out_of_range.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Hex_binary/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Hex_binary/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Hex_binary/odd_number_of_digits.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Hex_binary/odd_number_of_digits.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Hex_binary/single_digit.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Hex_binary/single_digit.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Int/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Int/decimal.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Int/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Int/empty.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Int/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Int/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Int/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Int/mathematical_formula.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Int/max_plus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Int/max_plus_one.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Int/min_minus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Int/min_minus_one.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Int/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Int/scientific.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Integer/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Integer/decimal.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Integer/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Integer/empty.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Integer/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Integer/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Integer/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Integer/mathematical_formula.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Integer/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Integer/scientific.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Long/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Long/decimal.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Long/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Long/empty.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Long/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Long/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Long/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Long/mathematical_formula.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Long/max_plus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Long/max_plus_one.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Long/min_minus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Long/min_minus_one.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Long/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Long/scientific.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Negative_integer/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Negative_integer/decimal.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Negative_integer/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Negative_integer/empty.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Negative_integer/explicitly_positive.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Negative_integer/explicitly_positive.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Negative_integer/explicitly_positive_zero.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Negative_integer/explicitly_positive_zero.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Negative_integer/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Negative_integer/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Negative_integer/implicitly_positive.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Negative_integer/implicitly_positive.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Negative_integer/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Negative_integer/mathematical_formula.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Negative_integer/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Negative_integer/scientific.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Negative_integer/zero.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Negative_integer/zero.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Negative_integer/zero_prefixed_with_zeros.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Negative_integer/zero_prefixed_with_zeros.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Non_negative_integer/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Non_negative_integer/decimal.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Non_negative_integer/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Non_negative_integer/empty.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Non_negative_integer/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Non_negative_integer/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Non_negative_integer/negative.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Non_negative_integer/negative.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Non_positive_integer/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Non_positive_integer/decimal.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Non_positive_integer/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Non_positive_integer/empty.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Non_positive_integer/explicitly_positive.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Non_positive_integer/explicitly_positive.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Non_positive_integer/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Non_positive_integer/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Non_positive_integer/implicitly_positive.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Non_positive_integer/implicitly_positive.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Non_positive_integer/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Non_positive_integer/mathematical_formula.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Non_positive_integer/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Non_positive_integer/scientific.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Positive_integer/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Positive_integer/decimal.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Positive_integer/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Positive_integer/empty.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Positive_integer/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Positive_integer/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Positive_integer/negative.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Positive_integer/negative.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Positive_integer/zero.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Positive_integer/zero.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Positive_integer/zero_prefixed_with_zeros.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Positive_integer/zero_prefixed_with_zeros.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Short/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Short/decimal.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Short/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Short/empty.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Short/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Short/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Short/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Short/mathematical_formula.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Short/max_plus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Short/max_plus_one.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Short/min_minus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Short/min_minus_one.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Short/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Short/scientific.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/String/NUL_as_utf16.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/String/NUL_as_utf16.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/String/NUL_as_utf32.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/String/NUL_as_utf32.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/String/NUL_as_x.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/String/NUL_as_x.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/String/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/String/negatively_fuzzed_01.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/String/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/String/negatively_fuzzed_02.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/String/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/String/negatively_fuzzed_03.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/String/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/String/negatively_fuzzed_04.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/String/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/String/negatively_fuzzed_05.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/String/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/String/negatively_fuzzed_06.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/String/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/String/negatively_fuzzed_07.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/String/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/String/negatively_fuzzed_08.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/String/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/String/negatively_fuzzed_09.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/String/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/String/negatively_fuzzed_10.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Time/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Time/empty.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Time/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Time/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Time/hour_out_of_range.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Time/hour_out_of_range.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Time/invalid_negative_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Time/invalid_negative_offset.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Time/invalid_offset_with_seconds.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Time/invalid_offset_with_seconds.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Time/invalid_positive_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Time/invalid_positive_offset.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Time/minute_out_of_range.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Time/minute_out_of_range.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Time/missing_padded_zeros.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Time/missing_padded_zeros.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Time/missing_seconds.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Time/missing_seconds.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Time/negative.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Time/negative.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Time/second_out_of_range.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Time/second_out_of_range.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_byte/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_byte/decimal.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_byte/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_byte/empty.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_byte/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_byte/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_byte/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_byte/mathematical_formula.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_byte/max_plus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_byte/max_plus_one.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_byte/negative.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_byte/negative.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_byte/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_byte/scientific.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_int/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_int/decimal.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_int/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_int/empty.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_int/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_int/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_int/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_int/mathematical_formula.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_int/max_plus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_int/max_plus_one.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_int/negative.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_int/negative.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_int/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_int/scientific.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_long/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_long/decimal.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_long/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_long/empty.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_long/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_long/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_long/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_long/mathematical_formula.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_long/max_plus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_long/max_plus_one.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_long/negative.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_long/negative.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_long/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_long/scientific.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_short/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_short/decimal.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_short/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_short/empty.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_short/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_short/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_short/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_short/mathematical_formula.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_short/max_plus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_short/max_plus_one.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_short/negative.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_short/negative.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_short/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Unsigned_short/scientific.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Year_month_duration/day.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Year_month_duration/day.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Year_month_duration/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Year_month_duration/empty.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Year_month_duration/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Year_month_duration/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Year_month_duration/hour_part.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Year_month_duration/hour_part.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Year_month_duration/negative_years.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Year_month_duration/negative_years.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Any_URI/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Any_URI/negatively_fuzzed_01.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Any_URI/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Any_URI/negatively_fuzzed_02.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Any_URI/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Any_URI/negatively_fuzzed_03.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Any_URI/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Any_URI/negatively_fuzzed_04.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Any_URI/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Any_URI/negatively_fuzzed_05.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Any_URI/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Any_URI/negatively_fuzzed_06.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Any_URI/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Any_URI/negatively_fuzzed_07.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Any_URI/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Any_URI/negatively_fuzzed_08.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Any_URI/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Any_URI/negatively_fuzzed_09.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Any_URI/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Any_URI/negatively_fuzzed_10.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Any_URI/percentage_followed_by_non_two_hexadecimal_digits.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Any_URI/percentage_followed_by_non_two_hexadecimal_digits.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Any_URI/too_many_fragments.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Any_URI/too_many_fragments.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Base_64_binary/an_odd_number_of_characters_is_not_valid.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Base_64_binary/an_odd_number_of_characters_is_not_valid.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Base_64_binary/equals_signs_may_only_appear_at_the_end.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Base_64_binary/equals_signs_may_only_appear_at_the_end.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Base_64_binary/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Base_64_binary/negatively_fuzzed_01.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Base_64_binary/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Base_64_binary/negatively_fuzzed_02.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Base_64_binary/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Base_64_binary/negatively_fuzzed_03.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Base_64_binary/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Base_64_binary/negatively_fuzzed_04.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Base_64_binary/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Base_64_binary/negatively_fuzzed_05.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Base_64_binary/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Base_64_binary/negatively_fuzzed_06.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Base_64_binary/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Base_64_binary/negatively_fuzzed_07.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Base_64_binary/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Base_64_binary/negatively_fuzzed_08.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Base_64_binary/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Base_64_binary/negatively_fuzzed_09.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Base_64_binary/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Base_64_binary/negatively_fuzzed_10.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Boolean/false_as_number_with_leading_zeros.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Boolean/false_as_number_with_leading_zeros.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Boolean/false_in_camelcase.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Boolean/false_in_camelcase.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Boolean/false_in_uppercase.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Boolean/false_in_uppercase.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Boolean/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Boolean/negatively_fuzzed_01.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Boolean/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Boolean/negatively_fuzzed_02.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Boolean/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Boolean/negatively_fuzzed_03.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Boolean/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Boolean/negatively_fuzzed_04.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Boolean/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Boolean/negatively_fuzzed_05.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Boolean/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Boolean/negatively_fuzzed_06.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Boolean/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Boolean/negatively_fuzzed_07.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Boolean/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Boolean/negatively_fuzzed_08.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Boolean/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Boolean/negatively_fuzzed_09.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Boolean/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Boolean/negatively_fuzzed_10.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Boolean/true_as_number_with_leading_zeros.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Boolean/true_as_number_with_leading_zeros.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Boolean/true_in_camelcase.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Boolean/true_in_camelcase.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Boolean/true_in_uppercase.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Boolean/true_in_uppercase.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Byte/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Byte/decimal.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Byte/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Byte/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Byte/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Byte/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Byte/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Byte/mathematical_formula.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Byte/max_plus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Byte/max_plus_one.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Byte/min_minus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Byte/min_minus_one.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Byte/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Byte/scientific.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/date_time_with_UTC.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/date_time_with_UTC.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/date_time_with_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/date_time_with_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/date_time_without_zone.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/date_time_without_zone.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/date_with_invalid_negative_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/date_with_invalid_negative_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/date_with_invalid_positive_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/date_with_invalid_positive_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/date_with_seconds_in_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/date_with_seconds_in_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/non_existing_february_29th.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/non_existing_february_29th.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/date.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/date.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/date_time_with_invalid_negative_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/date_time_with_invalid_negative_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/date_time_with_invalid_positive_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/date_time_with_invalid_positive_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/date_time_with_seconds_in_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/date_time_with_seconds_in_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/date_time_with_unexpected_prefix.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/date_time_with_unexpected_prefix.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/date_time_with_unexpected_suffix.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/date_time_with_unexpected_suffix.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/date_with_time_zone.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/date_with_time_zone.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/non_existing_february_29th.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/non_existing_february_29th.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/without_minutes.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/without_minutes.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/without_seconds.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/without_seconds.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/date.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/date.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/date_time_stamp_with_invalid_negative_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/date_time_stamp_with_invalid_negative_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/date_time_stamp_with_invalid_positive_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/date_time_stamp_with_invalid_positive_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/date_time_stamp_with_seconds_in_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/date_time_stamp_with_seconds_in_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/date_time_stamp_with_unexpected_prefix.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/date_time_stamp_with_unexpected_prefix.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/date_time_stamp_with_unexpected_suffix.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/date_time_stamp_with_unexpected_suffix.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/date_time_without_zone.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/date_time_without_zone.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/date_with_time_zone.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/date_with_time_zone.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/non_existing_february_29th.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/non_existing_february_29th.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/without_minutes.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/without_minutes.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/without_seconds.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/without_seconds.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Day_time_duration/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Day_time_duration/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Day_time_duration/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Day_time_duration/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Day_time_duration/month.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Day_time_duration/month.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Day_time_duration/negative_days.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Day_time_duration/negative_days.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Day_time_duration/year.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Day_time_duration/year.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Decimal/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Decimal/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Decimal/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Decimal/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Double/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Double/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Double/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Double/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Double/inf_case_matters.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Double/inf_case_matters.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Double/nan_case_matters.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Double/nan_case_matters.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Double/no_fraction_in_scientific_notation.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Double/no_fraction_in_scientific_notation.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Double/plus_inf.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Double/plus_inf.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Double/too_large.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Double/too_large.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Duration/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Duration/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Duration/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Duration/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Duration/integer.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Duration/integer.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Duration/leading_P_missing.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Duration/leading_P_missing.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Duration/negative_years.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Duration/negative_years.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Duration/positive_year_negative_months.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Duration/positive_year_negative_months.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Duration/separator_T_missing.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Duration/separator_T_missing.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Duration/the_order_matters.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Duration/the_order_matters.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Float/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Float/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Float/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Float/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Float/inf_case_matters.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Float/inf_case_matters.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Float/nan_case_matters.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Float/nan_case_matters.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Float/no_fraction_in_scientific_notation.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Float/no_fraction_in_scientific_notation.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Float/plus_inf.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Float/plus_inf.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Float/too_large.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Float/too_large.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_day/day_outside_of_range.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_day/day_outside_of_range.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_day/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_day/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_day/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_day/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_day/invalid_negative_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_day/invalid_negative_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_day/invalid_offset_with_seconds.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_day/invalid_offset_with_seconds.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_day/invalid_positive_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_day/invalid_positive_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_day/missing_leading_dashes.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_day/missing_leading_dashes.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_day/missing_leading_digit.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_day/missing_leading_digit.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_day/unexpected_suffix.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_day/unexpected_suffix.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_month/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_month/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_month/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_month/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_month/invalid_negative_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_month/invalid_negative_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_month/invalid_offset_with_seconds.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_month/invalid_offset_with_seconds.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_month/invalid_positive_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_month/invalid_positive_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_month/missing_leading_dashes.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_month/missing_leading_dashes.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_month/missing_leading_digit.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_month/missing_leading_digit.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_month/month_outside_of_range.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_month/month_outside_of_range.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_month/unexpected_prefix_and_suffix.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_month/unexpected_prefix_and_suffix.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_month_day/day_outside_of_range.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_month_day/day_outside_of_range.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_month_day/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_month_day/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_month_day/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_month_day/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_month_day/invalid_negative_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_month_day/invalid_negative_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_month_day/invalid_offset_with_seconds.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_month_day/invalid_offset_with_seconds.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_month_day/invalid_positive_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_month_day/invalid_positive_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_month_day/missing_leading_dashes.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_month_day/missing_leading_dashes.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_month_day/missing_leading_digit.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_month_day/missing_leading_digit.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_month_day/non_existing_april_31st.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_month_day/non_existing_april_31st.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_month_day/unexpected_prefix_and_suffix.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_month_day/unexpected_prefix_and_suffix.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_year/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_year/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_year/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_year/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_year/invalid_negative_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_year/invalid_negative_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_year/invalid_offset_with_seconds.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_year/invalid_offset_with_seconds.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_year/invalid_positive_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_year/invalid_positive_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_year/missing_century.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_year/missing_century.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_year/unexpected_month.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_year/unexpected_month.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_year_month/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_year_month/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_year_month/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_year_month/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_year_month/invalid_negative_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_year_month/invalid_negative_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_year_month/invalid_offset_with_seconds.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_year_month/invalid_offset_with_seconds.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_year_month/invalid_positive_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_year_month/invalid_positive_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_year_month/missing_century.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_year_month/missing_century.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_year_month/missing_month.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_year_month/missing_month.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_year_month/month_out_of_range.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/G_year_month/month_out_of_range.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Hex_binary/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Hex_binary/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Hex_binary/odd_number_of_digits.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Hex_binary/odd_number_of_digits.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Hex_binary/single_digit.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Hex_binary/single_digit.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Int/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Int/decimal.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Int/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Int/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Int/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Int/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Int/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Int/mathematical_formula.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Int/max_plus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Int/max_plus_one.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Int/min_minus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Int/min_minus_one.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Int/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Int/scientific.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Integer/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Integer/decimal.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Integer/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Integer/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Integer/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Integer/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Integer/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Integer/mathematical_formula.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Integer/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Integer/scientific.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Long/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Long/decimal.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Long/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Long/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Long/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Long/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Long/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Long/mathematical_formula.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Long/max_plus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Long/max_plus_one.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Long/min_minus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Long/min_minus_one.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Long/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Long/scientific.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Negative_integer/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Negative_integer/decimal.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Negative_integer/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Negative_integer/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Negative_integer/explicitly_positive.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Negative_integer/explicitly_positive.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Negative_integer/explicitly_positive_zero.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Negative_integer/explicitly_positive_zero.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Negative_integer/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Negative_integer/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Negative_integer/implicitly_positive.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Negative_integer/implicitly_positive.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Negative_integer/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Negative_integer/mathematical_formula.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Negative_integer/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Negative_integer/scientific.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Negative_integer/zero.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Negative_integer/zero.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Negative_integer/zero_prefixed_with_zeros.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Negative_integer/zero_prefixed_with_zeros.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Non_negative_integer/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Non_negative_integer/decimal.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Non_negative_integer/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Non_negative_integer/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Non_negative_integer/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Non_negative_integer/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Non_negative_integer/negative.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Non_negative_integer/negative.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Non_positive_integer/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Non_positive_integer/decimal.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Non_positive_integer/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Non_positive_integer/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Non_positive_integer/explicitly_positive.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Non_positive_integer/explicitly_positive.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Non_positive_integer/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Non_positive_integer/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Non_positive_integer/implicitly_positive.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Non_positive_integer/implicitly_positive.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Non_positive_integer/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Non_positive_integer/mathematical_formula.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Non_positive_integer/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Non_positive_integer/scientific.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Positive_integer/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Positive_integer/decimal.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Positive_integer/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Positive_integer/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Positive_integer/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Positive_integer/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Positive_integer/negative.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Positive_integer/negative.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Positive_integer/zero.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Positive_integer/zero.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Positive_integer/zero_prefixed_with_zeros.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Positive_integer/zero_prefixed_with_zeros.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Short/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Short/decimal.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Short/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Short/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Short/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Short/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Short/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Short/mathematical_formula.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Short/max_plus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Short/max_plus_one.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Short/min_minus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Short/min_minus_one.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Short/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Short/scientific.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/String/NUL_as_utf16.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/String/NUL_as_utf16.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/String/NUL_as_utf32.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/String/NUL_as_utf32.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/String/NUL_as_x.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/String/NUL_as_x.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/String/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/String/negatively_fuzzed_01.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/String/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/String/negatively_fuzzed_02.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/String/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/String/negatively_fuzzed_03.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/String/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/String/negatively_fuzzed_04.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/String/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/String/negatively_fuzzed_05.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/String/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/String/negatively_fuzzed_06.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/String/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/String/negatively_fuzzed_07.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/String/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/String/negatively_fuzzed_08.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/String/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/String/negatively_fuzzed_09.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/String/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/String/negatively_fuzzed_10.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Time/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Time/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Time/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Time/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Time/hour_out_of_range.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Time/hour_out_of_range.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Time/invalid_negative_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Time/invalid_negative_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Time/invalid_offset_with_seconds.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Time/invalid_offset_with_seconds.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Time/invalid_positive_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Time/invalid_positive_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Time/minute_out_of_range.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Time/minute_out_of_range.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Time/missing_padded_zeros.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Time/missing_padded_zeros.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Time/missing_seconds.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Time/missing_seconds.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Time/negative.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Time/negative.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Time/second_out_of_range.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Time/second_out_of_range.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_byte/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_byte/decimal.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_byte/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_byte/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_byte/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_byte/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_byte/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_byte/mathematical_formula.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_byte/max_plus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_byte/max_plus_one.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_byte/negative.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_byte/negative.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_byte/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_byte/scientific.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_int/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_int/decimal.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_int/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_int/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_int/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_int/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_int/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_int/mathematical_formula.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_int/max_plus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_int/max_plus_one.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_int/negative.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_int/negative.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_int/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_int/scientific.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_long/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_long/decimal.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_long/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_long/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_long/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_long/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_long/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_long/mathematical_formula.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_long/max_plus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_long/max_plus_one.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_long/negative.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_long/negative.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_long/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_long/scientific.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_short/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_short/decimal.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_short/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_short/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_short/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_short/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_short/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_short/mathematical_formula.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_short/max_plus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_short/max_plus_one.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_short/negative.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_short/negative.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_short/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Unsigned_short/scientific.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Year_month_duration/day.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Year_month_duration/day.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Year_month_duration/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Year_month_duration/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Year_month_duration/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Year_month_duration/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Year_month_duration/hour_part.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Year_month_duration/hour_part.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Year_month_duration/negative_years.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Year_month_duration/negative_years.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Any_URI/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Any_URI/negatively_fuzzed_01.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Any_URI/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Any_URI/negatively_fuzzed_02.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Any_URI/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Any_URI/negatively_fuzzed_03.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Any_URI/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Any_URI/negatively_fuzzed_04.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Any_URI/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Any_URI/negatively_fuzzed_05.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Any_URI/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Any_URI/negatively_fuzzed_06.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Any_URI/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Any_URI/negatively_fuzzed_07.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Any_URI/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Any_URI/negatively_fuzzed_08.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Any_URI/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Any_URI/negatively_fuzzed_09.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Any_URI/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Any_URI/negatively_fuzzed_10.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Any_URI/percentage_followed_by_non_two_hexadecimal_digits.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Any_URI/percentage_followed_by_non_two_hexadecimal_digits.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Any_URI/too_many_fragments.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Any_URI/too_many_fragments.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Base_64_binary/an_odd_number_of_characters_is_not_valid.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Base_64_binary/an_odd_number_of_characters_is_not_valid.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Base_64_binary/equals_signs_may_only_appear_at_the_end.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Base_64_binary/equals_signs_may_only_appear_at_the_end.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Base_64_binary/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Base_64_binary/negatively_fuzzed_01.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Base_64_binary/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Base_64_binary/negatively_fuzzed_02.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Base_64_binary/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Base_64_binary/negatively_fuzzed_03.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Base_64_binary/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Base_64_binary/negatively_fuzzed_04.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Base_64_binary/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Base_64_binary/negatively_fuzzed_05.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Base_64_binary/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Base_64_binary/negatively_fuzzed_06.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Base_64_binary/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Base_64_binary/negatively_fuzzed_07.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Base_64_binary/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Base_64_binary/negatively_fuzzed_08.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Base_64_binary/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Base_64_binary/negatively_fuzzed_09.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Base_64_binary/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Base_64_binary/negatively_fuzzed_10.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Boolean/false_as_number_with_leading_zeros.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Boolean/false_as_number_with_leading_zeros.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Boolean/false_in_camelcase.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Boolean/false_in_camelcase.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Boolean/false_in_uppercase.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Boolean/false_in_uppercase.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Boolean/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Boolean/negatively_fuzzed_01.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Boolean/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Boolean/negatively_fuzzed_02.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Boolean/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Boolean/negatively_fuzzed_03.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Boolean/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Boolean/negatively_fuzzed_04.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Boolean/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Boolean/negatively_fuzzed_05.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Boolean/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Boolean/negatively_fuzzed_06.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Boolean/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Boolean/negatively_fuzzed_07.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Boolean/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Boolean/negatively_fuzzed_08.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Boolean/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Boolean/negatively_fuzzed_09.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Boolean/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Boolean/negatively_fuzzed_10.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Boolean/true_as_number_with_leading_zeros.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Boolean/true_as_number_with_leading_zeros.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Boolean/true_in_camelcase.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Boolean/true_in_camelcase.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Boolean/true_in_uppercase.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Boolean/true_in_uppercase.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Byte/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Byte/decimal.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Byte/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Byte/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Byte/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Byte/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Byte/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Byte/mathematical_formula.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Byte/max_plus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Byte/max_plus_one.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Byte/min_minus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Byte/min_minus_one.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Byte/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Byte/scientific.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/date_time_with_UTC.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/date_time_with_UTC.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/date_time_with_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/date_time_with_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/date_time_without_zone.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/date_time_without_zone.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/date_with_invalid_negative_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/date_with_invalid_negative_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/date_with_invalid_positive_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/date_with_invalid_positive_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/date_with_seconds_in_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/date_with_seconds_in_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/non_existing_february_29th.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/non_existing_february_29th.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/date.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/date.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/date_time_with_invalid_negative_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/date_time_with_invalid_negative_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/date_time_with_invalid_positive_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/date_time_with_invalid_positive_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/date_time_with_seconds_in_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/date_time_with_seconds_in_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/date_time_with_unexpected_prefix.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/date_time_with_unexpected_prefix.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/date_time_with_unexpected_suffix.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/date_time_with_unexpected_suffix.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/date_with_time_zone.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/date_with_time_zone.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/non_existing_february_29th.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/non_existing_february_29th.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/without_minutes.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/without_minutes.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/without_seconds.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/without_seconds.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/date.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/date.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/date_time_stamp_with_invalid_negative_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/date_time_stamp_with_invalid_negative_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/date_time_stamp_with_invalid_positive_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/date_time_stamp_with_invalid_positive_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/date_time_stamp_with_seconds_in_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/date_time_stamp_with_seconds_in_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/date_time_stamp_with_unexpected_prefix.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/date_time_stamp_with_unexpected_prefix.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/date_time_stamp_with_unexpected_suffix.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/date_time_stamp_with_unexpected_suffix.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/date_time_without_zone.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/date_time_without_zone.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/date_with_time_zone.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/date_with_time_zone.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/non_existing_february_29th.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/non_existing_february_29th.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/without_minutes.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/without_minutes.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/without_seconds.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/without_seconds.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Day_time_duration/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Day_time_duration/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Day_time_duration/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Day_time_duration/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Day_time_duration/month.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Day_time_duration/month.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Day_time_duration/negative_days.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Day_time_duration/negative_days.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Day_time_duration/year.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Day_time_duration/year.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Decimal/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Decimal/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Decimal/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Decimal/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Double/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Double/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Double/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Double/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Double/inf_case_matters.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Double/inf_case_matters.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Double/nan_case_matters.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Double/nan_case_matters.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Double/no_fraction_in_scientific_notation.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Double/no_fraction_in_scientific_notation.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Double/plus_inf.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Double/plus_inf.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Double/too_large.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Double/too_large.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Duration/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Duration/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Duration/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Duration/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Duration/integer.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Duration/integer.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Duration/leading_P_missing.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Duration/leading_P_missing.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Duration/negative_years.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Duration/negative_years.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Duration/positive_year_negative_months.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Duration/positive_year_negative_months.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Duration/separator_T_missing.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Duration/separator_T_missing.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Duration/the_order_matters.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Duration/the_order_matters.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Float/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Float/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Float/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Float/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Float/inf_case_matters.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Float/inf_case_matters.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Float/nan_case_matters.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Float/nan_case_matters.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Float/no_fraction_in_scientific_notation.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Float/no_fraction_in_scientific_notation.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Float/plus_inf.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Float/plus_inf.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Float/too_large.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Float/too_large.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_day/day_outside_of_range.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_day/day_outside_of_range.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_day/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_day/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_day/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_day/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_day/invalid_negative_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_day/invalid_negative_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_day/invalid_offset_with_seconds.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_day/invalid_offset_with_seconds.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_day/invalid_positive_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_day/invalid_positive_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_day/missing_leading_dashes.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_day/missing_leading_dashes.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_day/missing_leading_digit.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_day/missing_leading_digit.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_day/unexpected_suffix.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_day/unexpected_suffix.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_month/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_month/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_month/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_month/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_month/invalid_negative_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_month/invalid_negative_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_month/invalid_offset_with_seconds.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_month/invalid_offset_with_seconds.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_month/invalid_positive_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_month/invalid_positive_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_month/missing_leading_dashes.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_month/missing_leading_dashes.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_month/missing_leading_digit.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_month/missing_leading_digit.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_month/month_outside_of_range.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_month/month_outside_of_range.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_month/unexpected_prefix_and_suffix.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_month/unexpected_prefix_and_suffix.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_month_day/day_outside_of_range.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_month_day/day_outside_of_range.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_month_day/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_month_day/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_month_day/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_month_day/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_month_day/invalid_negative_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_month_day/invalid_negative_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_month_day/invalid_offset_with_seconds.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_month_day/invalid_offset_with_seconds.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_month_day/invalid_positive_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_month_day/invalid_positive_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_month_day/missing_leading_dashes.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_month_day/missing_leading_dashes.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_month_day/missing_leading_digit.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_month_day/missing_leading_digit.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_month_day/non_existing_april_31st.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_month_day/non_existing_april_31st.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_month_day/unexpected_prefix_and_suffix.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_month_day/unexpected_prefix_and_suffix.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_year/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_year/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_year/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_year/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_year/invalid_negative_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_year/invalid_negative_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_year/invalid_offset_with_seconds.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_year/invalid_offset_with_seconds.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_year/invalid_positive_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_year/invalid_positive_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_year/missing_century.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_year/missing_century.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_year/unexpected_month.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_year/unexpected_month.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_year_month/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_year_month/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_year_month/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_year_month/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_year_month/invalid_negative_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_year_month/invalid_negative_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_year_month/invalid_offset_with_seconds.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_year_month/invalid_offset_with_seconds.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_year_month/invalid_positive_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_year_month/invalid_positive_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_year_month/missing_century.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_year_month/missing_century.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_year_month/missing_month.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_year_month/missing_month.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_year_month/month_out_of_range.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/G_year_month/month_out_of_range.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Hex_binary/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Hex_binary/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Hex_binary/odd_number_of_digits.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Hex_binary/odd_number_of_digits.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Hex_binary/single_digit.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Hex_binary/single_digit.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Int/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Int/decimal.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Int/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Int/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Int/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Int/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Int/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Int/mathematical_formula.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Int/max_plus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Int/max_plus_one.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Int/min_minus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Int/min_minus_one.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Int/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Int/scientific.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Integer/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Integer/decimal.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Integer/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Integer/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Integer/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Integer/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Integer/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Integer/mathematical_formula.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Integer/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Integer/scientific.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Long/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Long/decimal.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Long/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Long/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Long/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Long/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Long/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Long/mathematical_formula.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Long/max_plus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Long/max_plus_one.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Long/min_minus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Long/min_minus_one.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Long/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Long/scientific.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Negative_integer/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Negative_integer/decimal.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Negative_integer/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Negative_integer/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Negative_integer/explicitly_positive.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Negative_integer/explicitly_positive.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Negative_integer/explicitly_positive_zero.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Negative_integer/explicitly_positive_zero.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Negative_integer/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Negative_integer/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Negative_integer/implicitly_positive.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Negative_integer/implicitly_positive.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Negative_integer/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Negative_integer/mathematical_formula.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Negative_integer/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Negative_integer/scientific.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Negative_integer/zero.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Negative_integer/zero.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Negative_integer/zero_prefixed_with_zeros.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Negative_integer/zero_prefixed_with_zeros.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Non_negative_integer/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Non_negative_integer/decimal.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Non_negative_integer/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Non_negative_integer/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Non_negative_integer/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Non_negative_integer/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Non_negative_integer/negative.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Non_negative_integer/negative.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Non_positive_integer/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Non_positive_integer/decimal.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Non_positive_integer/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Non_positive_integer/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Non_positive_integer/explicitly_positive.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Non_positive_integer/explicitly_positive.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Non_positive_integer/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Non_positive_integer/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Non_positive_integer/implicitly_positive.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Non_positive_integer/implicitly_positive.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Non_positive_integer/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Non_positive_integer/mathematical_formula.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Non_positive_integer/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Non_positive_integer/scientific.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Positive_integer/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Positive_integer/decimal.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Positive_integer/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Positive_integer/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Positive_integer/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Positive_integer/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Positive_integer/negative.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Positive_integer/negative.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Positive_integer/zero.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Positive_integer/zero.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Positive_integer/zero_prefixed_with_zeros.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Positive_integer/zero_prefixed_with_zeros.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Short/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Short/decimal.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Short/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Short/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Short/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Short/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Short/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Short/mathematical_formula.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Short/max_plus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Short/max_plus_one.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Short/min_minus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Short/min_minus_one.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Short/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Short/scientific.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/String/NUL_as_utf16.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/String/NUL_as_utf16.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/String/NUL_as_utf32.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/String/NUL_as_utf32.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/String/NUL_as_x.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/String/NUL_as_x.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/String/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/String/negatively_fuzzed_01.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/String/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/String/negatively_fuzzed_02.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/String/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/String/negatively_fuzzed_03.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/String/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/String/negatively_fuzzed_04.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/String/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/String/negatively_fuzzed_05.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/String/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/String/negatively_fuzzed_06.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/String/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/String/negatively_fuzzed_07.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/String/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/String/negatively_fuzzed_08.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/String/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/String/negatively_fuzzed_09.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/String/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/String/negatively_fuzzed_10.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Time/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Time/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Time/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Time/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Time/hour_out_of_range.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Time/hour_out_of_range.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Time/invalid_negative_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Time/invalid_negative_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Time/invalid_offset_with_seconds.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Time/invalid_offset_with_seconds.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Time/invalid_positive_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Time/invalid_positive_offset.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Time/minute_out_of_range.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Time/minute_out_of_range.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Time/missing_padded_zeros.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Time/missing_padded_zeros.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Time/missing_seconds.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Time/missing_seconds.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Time/negative.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Time/negative.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Time/second_out_of_range.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Time/second_out_of_range.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_byte/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_byte/decimal.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_byte/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_byte/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_byte/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_byte/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_byte/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_byte/mathematical_formula.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_byte/max_plus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_byte/max_plus_one.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_byte/negative.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_byte/negative.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_byte/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_byte/scientific.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_int/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_int/decimal.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_int/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_int/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_int/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_int/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_int/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_int/mathematical_formula.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_int/max_plus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_int/max_plus_one.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_int/negative.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_int/negative.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_int/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_int/scientific.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_long/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_long/decimal.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_long/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_long/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_long/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_long/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_long/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_long/mathematical_formula.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_long/max_plus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_long/max_plus_one.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_long/negative.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_long/negative.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_long/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_long/scientific.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_short/decimal.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_short/decimal.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_short/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_short/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_short/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_short/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_short/mathematical_formula.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_short/mathematical_formula.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_short/max_plus_one.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_short/max_plus_one.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_short/negative.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_short/negative.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_short/scientific.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Unsigned_short/scientific.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Year_month_duration/day.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Year_month_duration/day.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Year_month_duration/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Year_month_duration/empty.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Year_month_duration/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Year_month_duration/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Year_month_duration/hour_part.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Year_month_duration/hour_part.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Year_month_duration/negative_years.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Year_month_duration/negative_years.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AnnotatedRelationshipElement/idShort/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AnnotatedRelationshipElement/idShort/negatively_fuzzed_01.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AnnotatedRelationshipElement/idShort/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AnnotatedRelationshipElement/idShort/negatively_fuzzed_02.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AnnotatedRelationshipElement/idShort/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AnnotatedRelationshipElement/idShort/negatively_fuzzed_03.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AnnotatedRelationshipElement/idShort/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AnnotatedRelationshipElement/idShort/negatively_fuzzed_04.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AnnotatedRelationshipElement/idShort/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AnnotatedRelationshipElement/idShort/negatively_fuzzed_05.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AnnotatedRelationshipElement/idShort/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AnnotatedRelationshipElement/idShort/negatively_fuzzed_06.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AnnotatedRelationshipElement/idShort/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AnnotatedRelationshipElement/idShort/negatively_fuzzed_07.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AnnotatedRelationshipElement/idShort/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AnnotatedRelationshipElement/idShort/negatively_fuzzed_08.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AnnotatedRelationshipElement/idShort/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AnnotatedRelationshipElement/idShort/negatively_fuzzed_09.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AnnotatedRelationshipElement/idShort/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AnnotatedRelationshipElement/idShort/negatively_fuzzed_10.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AssetAdministrationShell/idShort/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AssetAdministrationShell/idShort/negatively_fuzzed_01.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AssetAdministrationShell/idShort/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AssetAdministrationShell/idShort/negatively_fuzzed_02.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AssetAdministrationShell/idShort/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AssetAdministrationShell/idShort/negatively_fuzzed_03.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AssetAdministrationShell/idShort/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AssetAdministrationShell/idShort/negatively_fuzzed_04.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AssetAdministrationShell/idShort/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AssetAdministrationShell/idShort/negatively_fuzzed_05.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AssetAdministrationShell/idShort/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AssetAdministrationShell/idShort/negatively_fuzzed_06.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AssetAdministrationShell/idShort/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AssetAdministrationShell/idShort/negatively_fuzzed_07.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AssetAdministrationShell/idShort/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AssetAdministrationShell/idShort/negatively_fuzzed_08.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AssetAdministrationShell/idShort/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AssetAdministrationShell/idShort/negatively_fuzzed_09.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AssetAdministrationShell/idShort/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/AssetAdministrationShell/idShort/negatively_fuzzed_10.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_01.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_02.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_03.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_04.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_05.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_06.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_07.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_08.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_09.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/idShort/negatively_fuzzed_10.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/date_time_with_UTC_and_suffix.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/date_time_with_UTC_and_suffix.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].last_update: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].last_update: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/date_time_with_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/date_time_with_offset.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].last_update: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].last_update: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/date_time_without_zone.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/date_time_without_zone.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].last_update: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].last_update: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/empty.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].last_update: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].last_update: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_01.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].last_update: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].last_update: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_02.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].last_update: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].last_update: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_03.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].last_update: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].last_update: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_04.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].last_update: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].last_update: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_05.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].last_update: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].last_update: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_06.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].last_update: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].last_update: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_07.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].last_update: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].last_update: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_08.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].last_update: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].last_update: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_09.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].last_update: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].last_update: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/negatively_fuzzed_10.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].last_update: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].last_update: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/only_date.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/only_date.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].last_update: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].last_update: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/only_date_with_time_zone.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/only_date_with_time_zone.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].last_update: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].last_update: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/without_minutes.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/without_minutes.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].last_update: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].last_update: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/without_seconds.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/lastUpdate/without_seconds.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].last_update: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].last_update: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/date_time_with_UTC_and_suffix.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/date_time_with_UTC_and_suffix.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].max_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].max_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/date_time_with_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/date_time_with_offset.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].max_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].max_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/date_time_without_zone.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/date_time_without_zone.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].max_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].max_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/empty.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].max_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].max_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_01.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].max_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].max_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_02.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].max_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].max_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_03.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].max_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].max_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_04.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].max_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].max_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_05.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].max_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].max_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_06.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].max_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].max_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_07.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].max_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].max_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_08.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].max_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].max_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_09.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].max_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].max_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/negatively_fuzzed_10.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].max_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].max_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/only_date.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/only_date.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].max_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].max_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/only_date_with_time_zone.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/only_date_with_time_zone.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].max_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].max_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/without_minutes.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/without_minutes.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].max_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].max_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/without_seconds.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/maxInterval/without_seconds.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].max_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].max_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/date_time_with_UTC_and_suffix.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/date_time_with_UTC_and_suffix.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].min_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].min_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/date_time_with_offset.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/date_time_with_offset.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].min_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].min_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/date_time_without_zone.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/date_time_without_zone.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].min_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].min_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/empty.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].min_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].min_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_01.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].min_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].min_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_02.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].min_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].min_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_03.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].min_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].min_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_04.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].min_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].min_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_05.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].min_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].min_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_06.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].min_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].min_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_07.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].min_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].min_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_08.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].min_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].min_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_09.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].min_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].min_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/negatively_fuzzed_10.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].min_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].min_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/only_date.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/only_date.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].min_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].min_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/only_date_with_time_zone.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/only_date_with_time_zone.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].min_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].min_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/without_minutes.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/without_minutes.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].min_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].min_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/without_seconds.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/BasicEventElement/minInterval/without_seconds.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].min_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].min_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/contentType/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/contentType/empty.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].content_type: Constraint AASd-100: An attribute with data type ``string`` is not allowed to be empty.
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/contentType/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/contentType/negatively_fuzzed_01.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/contentType/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/contentType/negatively_fuzzed_02.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/contentType/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/contentType/negatively_fuzzed_03.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/contentType/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/contentType/negatively_fuzzed_04.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/contentType/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/contentType/negatively_fuzzed_05.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/contentType/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/contentType/negatively_fuzzed_06.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/contentType/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/contentType/negatively_fuzzed_07.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/contentType/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/contentType/negatively_fuzzed_08.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].content_type: Constraint AASd-100: An attribute with data type ``string`` is not allowed to be empty.
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/contentType/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/contentType/negatively_fuzzed_09.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/contentType/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/contentType/negatively_fuzzed_10.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/contentType/number.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/contentType/number.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/idShort/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/idShort/negatively_fuzzed_01.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/idShort/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/idShort/negatively_fuzzed_02.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/idShort/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/idShort/negatively_fuzzed_03.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/idShort/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/idShort/negatively_fuzzed_04.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/idShort/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/idShort/negatively_fuzzed_05.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/idShort/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/idShort/negatively_fuzzed_06.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/idShort/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/idShort/negatively_fuzzed_07.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/idShort/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/idShort/negatively_fuzzed_08.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/idShort/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/idShort/negatively_fuzzed_09.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/idShort/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Blob/idShort/negatively_fuzzed_10.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Capability/idShort/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Capability/idShort/negatively_fuzzed_01.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Capability/idShort/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Capability/idShort/negatively_fuzzed_02.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Capability/idShort/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Capability/idShort/negatively_fuzzed_03.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Capability/idShort/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Capability/idShort/negatively_fuzzed_04.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Capability/idShort/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Capability/idShort/negatively_fuzzed_05.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Capability/idShort/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Capability/idShort/negatively_fuzzed_06.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Capability/idShort/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Capability/idShort/negatively_fuzzed_07.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Capability/idShort/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Capability/idShort/negatively_fuzzed_08.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Capability/idShort/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Capability/idShort/negatively_fuzzed_09.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Capability/idShort/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Capability/idShort/negatively_fuzzed_10.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ConceptDescription/idShort/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ConceptDescription/idShort/negatively_fuzzed_01.json.errors
@@ -1,0 +1,1 @@
+.concept_descriptions[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ConceptDescription/idShort/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ConceptDescription/idShort/negatively_fuzzed_02.json.errors
@@ -1,0 +1,1 @@
+.concept_descriptions[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ConceptDescription/idShort/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ConceptDescription/idShort/negatively_fuzzed_03.json.errors
@@ -1,0 +1,1 @@
+.concept_descriptions[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ConceptDescription/idShort/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ConceptDescription/idShort/negatively_fuzzed_04.json.errors
@@ -1,0 +1,1 @@
+.concept_descriptions[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ConceptDescription/idShort/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ConceptDescription/idShort/negatively_fuzzed_05.json.errors
@@ -1,0 +1,1 @@
+.concept_descriptions[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ConceptDescription/idShort/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ConceptDescription/idShort/negatively_fuzzed_06.json.errors
@@ -1,0 +1,1 @@
+.concept_descriptions[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ConceptDescription/idShort/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ConceptDescription/idShort/negatively_fuzzed_07.json.errors
@@ -1,0 +1,1 @@
+.concept_descriptions[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ConceptDescription/idShort/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ConceptDescription/idShort/negatively_fuzzed_08.json.errors
@@ -1,0 +1,1 @@
+.concept_descriptions[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ConceptDescription/idShort/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ConceptDescription/idShort/negatively_fuzzed_09.json.errors
@@ -1,0 +1,1 @@
+.concept_descriptions[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ConceptDescription/idShort/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ConceptDescription/idShort/negatively_fuzzed_10.json.errors
@@ -1,0 +1,1 @@
+.concept_descriptions[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Entity/idShort/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Entity/idShort/negatively_fuzzed_01.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Entity/idShort/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Entity/idShort/negatively_fuzzed_02.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Entity/idShort/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Entity/idShort/negatively_fuzzed_03.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Entity/idShort/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Entity/idShort/negatively_fuzzed_04.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Entity/idShort/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Entity/idShort/negatively_fuzzed_05.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Entity/idShort/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Entity/idShort/negatively_fuzzed_06.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Entity/idShort/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Entity/idShort/negatively_fuzzed_07.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Entity/idShort/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Entity/idShort/negatively_fuzzed_08.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Entity/idShort/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Entity/idShort/negatively_fuzzed_09.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Entity/idShort/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Entity/idShort/negatively_fuzzed_10.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/contentType/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/contentType/empty.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].content_type: Constraint AASd-100: An attribute with data type ``string`` is not allowed to be empty.
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/contentType/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/contentType/negatively_fuzzed_01.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/contentType/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/contentType/negatively_fuzzed_02.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/contentType/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/contentType/negatively_fuzzed_03.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/contentType/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/contentType/negatively_fuzzed_04.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/contentType/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/contentType/negatively_fuzzed_05.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/contentType/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/contentType/negatively_fuzzed_06.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/contentType/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/contentType/negatively_fuzzed_07.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/contentType/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/contentType/negatively_fuzzed_08.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].content_type: Constraint AASd-100: An attribute with data type ``string`` is not allowed to be empty.
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/contentType/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/contentType/negatively_fuzzed_09.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/contentType/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/contentType/negatively_fuzzed_10.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/contentType/number.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/contentType/number.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/idShort/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/idShort/negatively_fuzzed_01.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/idShort/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/idShort/negatively_fuzzed_02.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/idShort/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/idShort/negatively_fuzzed_03.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/idShort/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/idShort/negatively_fuzzed_04.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/idShort/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/idShort/negatively_fuzzed_05.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/idShort/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/idShort/negatively_fuzzed_06.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/idShort/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/idShort/negatively_fuzzed_07.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/idShort/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/idShort/negatively_fuzzed_08.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/idShort/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/idShort/negatively_fuzzed_09.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/idShort/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/idShort/negatively_fuzzed_10.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/value/absolute_path_without_scheme.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/value/absolute_path_without_scheme.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].value: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/value/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/value/empty.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].value: Constraint AASd-100: An attribute with data type ``string`` is not allowed to be empty.
+.submodels[0].submodel_elements[0].value: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/value/local_relative_path_with_scheme.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/value/local_relative_path_with_scheme.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].value: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/value/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/value/negatively_fuzzed_01.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].value: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/value/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/value/negatively_fuzzed_02.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].value: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/value/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/value/negatively_fuzzed_03.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].value: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/value/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/value/negatively_fuzzed_04.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].value: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/value/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/value/negatively_fuzzed_05.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].value: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/value/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/value/negatively_fuzzed_06.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].value: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/value/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/value/negatively_fuzzed_07.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].value: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/value/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/value/negatively_fuzzed_08.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].value: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/value/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/value/negatively_fuzzed_09.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].value: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/value/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/value/negatively_fuzzed_10.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].value: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/value/number.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/value/number.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].value: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/value/relative_path_without_scheme.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/File/value/relative_path_without_scheme.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].value: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/LangString/language/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/LangString/language/empty.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].display_name[0].language: The value must represent a value language tag conformant to BCP 47.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/LangString/language/free_form_text.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/LangString/language/free_form_text.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].display_name[0].language: The value must represent a value language tag conformant to BCP 47.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/LangString/language/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/LangString/language/negatively_fuzzed_01.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].display_name[0].language: The value must represent a value language tag conformant to BCP 47.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/LangString/language/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/LangString/language/negatively_fuzzed_02.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].display_name[0].language: The value must represent a value language tag conformant to BCP 47.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/LangString/language/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/LangString/language/negatively_fuzzed_03.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].display_name[0].language: The value must represent a value language tag conformant to BCP 47.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/LangString/language/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/LangString/language/negatively_fuzzed_04.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].display_name[0].language: The value must represent a value language tag conformant to BCP 47.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/LangString/language/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/LangString/language/negatively_fuzzed_05.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].display_name[0].language: The value must represent a value language tag conformant to BCP 47.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/LangString/language/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/LangString/language/negatively_fuzzed_06.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].display_name[0].language: The value must represent a value language tag conformant to BCP 47.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/LangString/language/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/LangString/language/negatively_fuzzed_07.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].display_name[0].language: The value must represent a value language tag conformant to BCP 47.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/LangString/language/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/LangString/language/negatively_fuzzed_08.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].display_name[0].language: The value must represent a value language tag conformant to BCP 47.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/LangString/language/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/LangString/language/negatively_fuzzed_09.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].display_name[0].language: The value must represent a value language tag conformant to BCP 47.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/LangString/language/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/LangString/language/negatively_fuzzed_10.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].display_name[0].language: The value must represent a value language tag conformant to BCP 47.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/MultiLanguageProperty/idShort/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/MultiLanguageProperty/idShort/negatively_fuzzed_01.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/MultiLanguageProperty/idShort/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/MultiLanguageProperty/idShort/negatively_fuzzed_02.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/MultiLanguageProperty/idShort/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/MultiLanguageProperty/idShort/negatively_fuzzed_03.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/MultiLanguageProperty/idShort/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/MultiLanguageProperty/idShort/negatively_fuzzed_04.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/MultiLanguageProperty/idShort/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/MultiLanguageProperty/idShort/negatively_fuzzed_05.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/MultiLanguageProperty/idShort/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/MultiLanguageProperty/idShort/negatively_fuzzed_06.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/MultiLanguageProperty/idShort/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/MultiLanguageProperty/idShort/negatively_fuzzed_07.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/MultiLanguageProperty/idShort/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/MultiLanguageProperty/idShort/negatively_fuzzed_08.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/MultiLanguageProperty/idShort/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/MultiLanguageProperty/idShort/negatively_fuzzed_09.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/MultiLanguageProperty/idShort/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/MultiLanguageProperty/idShort/negatively_fuzzed_10.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Operation/idShort/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Operation/idShort/negatively_fuzzed_01.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Operation/idShort/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Operation/idShort/negatively_fuzzed_02.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Operation/idShort/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Operation/idShort/negatively_fuzzed_03.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Operation/idShort/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Operation/idShort/negatively_fuzzed_04.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Operation/idShort/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Operation/idShort/negatively_fuzzed_05.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Operation/idShort/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Operation/idShort/negatively_fuzzed_06.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Operation/idShort/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Operation/idShort/negatively_fuzzed_07.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Operation/idShort/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Operation/idShort/negatively_fuzzed_08.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Operation/idShort/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Operation/idShort/negatively_fuzzed_09.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Operation/idShort/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Operation/idShort/negatively_fuzzed_10.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Property/idShort/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Property/idShort/negatively_fuzzed_01.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Property/idShort/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Property/idShort/negatively_fuzzed_02.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Property/idShort/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Property/idShort/negatively_fuzzed_03.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Property/idShort/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Property/idShort/negatively_fuzzed_04.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Property/idShort/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Property/idShort/negatively_fuzzed_05.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Property/idShort/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Property/idShort/negatively_fuzzed_06.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Property/idShort/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Property/idShort/negatively_fuzzed_07.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Property/idShort/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Property/idShort/negatively_fuzzed_08.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Property/idShort/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Property/idShort/negatively_fuzzed_09.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Property/idShort/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Property/idShort/negatively_fuzzed_10.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Range/idShort/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Range/idShort/negatively_fuzzed_01.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Range/idShort/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Range/idShort/negatively_fuzzed_02.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Range/idShort/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Range/idShort/negatively_fuzzed_03.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Range/idShort/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Range/idShort/negatively_fuzzed_04.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Range/idShort/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Range/idShort/negatively_fuzzed_05.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Range/idShort/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Range/idShort/negatively_fuzzed_06.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Range/idShort/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Range/idShort/negatively_fuzzed_07.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Range/idShort/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Range/idShort/negatively_fuzzed_08.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Range/idShort/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Range/idShort/negatively_fuzzed_09.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Range/idShort/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Range/idShort/negatively_fuzzed_10.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ReferenceElement/idShort/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ReferenceElement/idShort/negatively_fuzzed_01.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ReferenceElement/idShort/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ReferenceElement/idShort/negatively_fuzzed_02.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ReferenceElement/idShort/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ReferenceElement/idShort/negatively_fuzzed_03.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ReferenceElement/idShort/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ReferenceElement/idShort/negatively_fuzzed_04.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ReferenceElement/idShort/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ReferenceElement/idShort/negatively_fuzzed_05.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ReferenceElement/idShort/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ReferenceElement/idShort/negatively_fuzzed_06.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ReferenceElement/idShort/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ReferenceElement/idShort/negatively_fuzzed_07.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ReferenceElement/idShort/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ReferenceElement/idShort/negatively_fuzzed_08.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ReferenceElement/idShort/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ReferenceElement/idShort/negatively_fuzzed_09.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ReferenceElement/idShort/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/ReferenceElement/idShort/negatively_fuzzed_10.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/RelationshipElement/idShort/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/RelationshipElement/idShort/negatively_fuzzed_01.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/RelationshipElement/idShort/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/RelationshipElement/idShort/negatively_fuzzed_02.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/RelationshipElement/idShort/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/RelationshipElement/idShort/negatively_fuzzed_03.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/RelationshipElement/idShort/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/RelationshipElement/idShort/negatively_fuzzed_04.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/RelationshipElement/idShort/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/RelationshipElement/idShort/negatively_fuzzed_05.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/RelationshipElement/idShort/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/RelationshipElement/idShort/negatively_fuzzed_06.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/RelationshipElement/idShort/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/RelationshipElement/idShort/negatively_fuzzed_07.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/RelationshipElement/idShort/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/RelationshipElement/idShort/negatively_fuzzed_08.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/RelationshipElement/idShort/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/RelationshipElement/idShort/negatively_fuzzed_09.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/RelationshipElement/idShort/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/RelationshipElement/idShort/negatively_fuzzed_10.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/contentType/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/contentType/empty.json.errors
@@ -1,0 +1,2 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.content_type: Constraint AASd-100: An attribute with data type ``string`` is not allowed to be empty.
+.asset_administration_shells[0].asset_information.default_thumbnail.content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/contentType/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/contentType/negatively_fuzzed_01.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/contentType/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/contentType/negatively_fuzzed_02.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/contentType/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/contentType/negatively_fuzzed_03.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/contentType/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/contentType/negatively_fuzzed_04.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/contentType/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/contentType/negatively_fuzzed_05.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/contentType/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/contentType/negatively_fuzzed_06.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/contentType/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/contentType/negatively_fuzzed_07.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/contentType/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/contentType/negatively_fuzzed_08.json.errors
@@ -1,0 +1,2 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.content_type: Constraint AASd-100: An attribute with data type ``string`` is not allowed to be empty.
+.asset_administration_shells[0].asset_information.default_thumbnail.content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/contentType/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/contentType/negatively_fuzzed_09.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/contentType/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/contentType/negatively_fuzzed_10.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/contentType/number.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/contentType/number.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/path/absolute_path_without_scheme.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/path/absolute_path_without_scheme.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.path: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/path/empty.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/path/empty.json.errors
@@ -1,0 +1,2 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.path: Constraint AASd-100: An attribute with data type ``string`` is not allowed to be empty.
+.asset_administration_shells[0].asset_information.default_thumbnail.path: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/path/local_relative_path_with_scheme.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/path/local_relative_path_with_scheme.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.path: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/path/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/path/negatively_fuzzed_01.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.path: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/path/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/path/negatively_fuzzed_02.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.path: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/path/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/path/negatively_fuzzed_03.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.path: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/path/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/path/negatively_fuzzed_04.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.path: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/path/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/path/negatively_fuzzed_05.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.path: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/path/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/path/negatively_fuzzed_06.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.path: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/path/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/path/negatively_fuzzed_07.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.path: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/path/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/path/negatively_fuzzed_08.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.path: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/path/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/path/negatively_fuzzed_09.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.path: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/path/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/path/negatively_fuzzed_10.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.path: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/path/number.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/path/number.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.path: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/path/relative_path_without_scheme.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Resource/path/relative_path_without_scheme.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.path: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Submodel/idShort/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Submodel/idShort/negatively_fuzzed_01.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Submodel/idShort/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Submodel/idShort/negatively_fuzzed_02.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Submodel/idShort/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Submodel/idShort/negatively_fuzzed_03.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Submodel/idShort/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Submodel/idShort/negatively_fuzzed_04.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Submodel/idShort/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Submodel/idShort/negatively_fuzzed_05.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Submodel/idShort/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Submodel/idShort/negatively_fuzzed_06.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Submodel/idShort/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Submodel/idShort/negatively_fuzzed_07.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Submodel/idShort/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Submodel/idShort/negatively_fuzzed_08.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Submodel/idShort/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Submodel/idShort/negatively_fuzzed_09.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Submodel/idShort/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/Submodel/idShort/negatively_fuzzed_10.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementCollection/idShort/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementCollection/idShort/negatively_fuzzed_01.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementCollection/idShort/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementCollection/idShort/negatively_fuzzed_02.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementCollection/idShort/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementCollection/idShort/negatively_fuzzed_03.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementCollection/idShort/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementCollection/idShort/negatively_fuzzed_04.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementCollection/idShort/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementCollection/idShort/negatively_fuzzed_05.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementCollection/idShort/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementCollection/idShort/negatively_fuzzed_06.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementCollection/idShort/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementCollection/idShort/negatively_fuzzed_07.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementCollection/idShort/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementCollection/idShort/negatively_fuzzed_08.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementCollection/idShort/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementCollection/idShort/negatively_fuzzed_09.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementCollection/idShort/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementCollection/idShort/negatively_fuzzed_10.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementList/idShort/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementList/idShort/negatively_fuzzed_01.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementList/idShort/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementList/idShort/negatively_fuzzed_02.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementList/idShort/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementList/idShort/negatively_fuzzed_03.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementList/idShort/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementList/idShort/negatively_fuzzed_04.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementList/idShort/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementList/idShort/negatively_fuzzed_05.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementList/idShort/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementList/idShort/negatively_fuzzed_06.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementList/idShort/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementList/idShort/negatively_fuzzed_07.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementList/idShort/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementList/idShort/negatively_fuzzed_08.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementList/idShort/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementList/idShort/negatively_fuzzed_09.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementList/idShort/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/PatternViolation/SubmodelElementList/idShort/negatively_fuzzed_10.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/date_time_with_UTC_and_suffix.json.errors
+++ b/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/date_time_with_UTC_and_suffix.json.errors
@@ -1,0 +1,2 @@
+.time_stamp: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.time_stamp: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/date_time_with_offset.json.errors
+++ b/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/date_time_with_offset.json.errors
@@ -1,0 +1,2 @@
+.time_stamp: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.time_stamp: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/date_time_without_zone.json.errors
+++ b/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/date_time_without_zone.json.errors
@@ -1,0 +1,2 @@
+.time_stamp: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.time_stamp: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/empty.json.errors
+++ b/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/empty.json.errors
@@ -1,0 +1,2 @@
+.time_stamp: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.time_stamp: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_01.json.errors
@@ -1,0 +1,2 @@
+.time_stamp: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.time_stamp: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_02.json.errors
@@ -1,0 +1,2 @@
+.time_stamp: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.time_stamp: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_03.json.errors
@@ -1,0 +1,2 @@
+.time_stamp: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.time_stamp: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_04.json.errors
@@ -1,0 +1,2 @@
+.time_stamp: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.time_stamp: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_05.json.errors
@@ -1,0 +1,2 @@
+.time_stamp: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.time_stamp: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_06.json.errors
@@ -1,0 +1,2 @@
+.time_stamp: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.time_stamp: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_07.json.errors
@@ -1,0 +1,2 @@
+.time_stamp: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.time_stamp: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_08.json.errors
@@ -1,0 +1,2 @@
+.time_stamp: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.time_stamp: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_09.json.errors
@@ -1,0 +1,2 @@
+.time_stamp: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.time_stamp: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/negatively_fuzzed_10.json.errors
@@ -1,0 +1,2 @@
+.time_stamp: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.time_stamp: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/only_date.json.errors
+++ b/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/only_date.json.errors
@@ -1,0 +1,2 @@
+.time_stamp: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.time_stamp: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/only_date_with_time_zone.json.errors
+++ b/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/only_date_with_time_zone.json.errors
@@ -1,0 +1,2 @@
+.time_stamp: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.time_stamp: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/without_minutes.json.errors
+++ b/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/without_minutes.json.errors
@@ -1,0 +1,2 @@
+.time_stamp: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.time_stamp: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/without_seconds.json.errors
+++ b/test_data/Json/SelfContained/Unexpected/PatternViolation/EventPayload/timeStamp/without_seconds.json.errors
@@ -1,0 +1,2 @@
+.time_stamp: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.time_stamp: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Any_URI/negatively_fuzzed_01.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Any_URI/negatively_fuzzed_01.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Any_URI/negatively_fuzzed_04.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Any_URI/negatively_fuzzed_04.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Any_URI/negatively_fuzzed_05.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Any_URI/negatively_fuzzed_05.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Any_URI/negatively_fuzzed_06.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Any_URI/negatively_fuzzed_06.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Any_URI/negatively_fuzzed_10.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Any_URI/negatively_fuzzed_10.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Any_URI/percentage_followed_by_non_two_hexadecimal_digits.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Any_URI/percentage_followed_by_non_two_hexadecimal_digits.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Any_URI/too_many_fragments.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Any_URI/too_many_fragments.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Base_64_binary/an_odd_number_of_characters_is_not_valid.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Base_64_binary/an_odd_number_of_characters_is_not_valid.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Base_64_binary/equals_signs_may_only_appear_at_the_end.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Base_64_binary/equals_signs_may_only_appear_at_the_end.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Base_64_binary/negatively_fuzzed_03.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Base_64_binary/negatively_fuzzed_03.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Base_64_binary/negatively_fuzzed_04.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Base_64_binary/negatively_fuzzed_04.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Base_64_binary/negatively_fuzzed_05.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Base_64_binary/negatively_fuzzed_05.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Base_64_binary/negatively_fuzzed_06.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Base_64_binary/negatively_fuzzed_06.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Base_64_binary/negatively_fuzzed_08.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Base_64_binary/negatively_fuzzed_08.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Base_64_binary/negatively_fuzzed_10.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Base_64_binary/negatively_fuzzed_10.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Boolean/false_as_number_with_leading_zeros.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Boolean/false_as_number_with_leading_zeros.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Boolean/false_in_camelcase.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Boolean/false_in_camelcase.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Boolean/false_in_uppercase.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Boolean/false_in_uppercase.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Boolean/negatively_fuzzed_01.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Boolean/negatively_fuzzed_01.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Boolean/negatively_fuzzed_03.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Boolean/negatively_fuzzed_03.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Boolean/negatively_fuzzed_05.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Boolean/negatively_fuzzed_05.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Boolean/negatively_fuzzed_10.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Boolean/negatively_fuzzed_10.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Boolean/true_as_number_with_leading_zeros.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Boolean/true_as_number_with_leading_zeros.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Boolean/true_in_camelcase.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Boolean/true_in_camelcase.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Boolean/true_in_uppercase.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Boolean/true_in_uppercase.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Byte/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Byte/decimal.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Byte/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Byte/empty.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Byte/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Byte/free_form_text.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Byte/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Byte/mathematical_formula.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Byte/max_plus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Byte/max_plus_one.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Byte/min_minus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Byte/min_minus_one.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Byte/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Byte/scientific.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date/date_time_with_UTC.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date/date_time_with_UTC.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date/date_time_with_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date/date_time_with_offset.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date/date_time_without_zone.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date/date_time_without_zone.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date/date_with_invalid_negative_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date/date_with_invalid_negative_offset.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date/date_with_invalid_positive_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date/date_with_invalid_positive_offset.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date/date_with_seconds_in_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date/date_with_seconds_in_offset.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date/empty.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date/non_existing_february_29th.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date/non_existing_february_29th.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/date.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/date.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/date_time_with_invalid_negative_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/date_time_with_invalid_negative_offset.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/date_time_with_invalid_positive_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/date_time_with_invalid_positive_offset.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/date_time_with_seconds_in_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/date_time_with_seconds_in_offset.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/date_time_with_unexpected_prefix.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/date_time_with_unexpected_prefix.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/date_time_with_unexpected_suffix.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/date_time_with_unexpected_suffix.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/date_with_time_zone.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/date_with_time_zone.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/empty.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/non_existing_february_29th.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/non_existing_february_29th.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/without_minutes.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/without_minutes.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/without_seconds.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/without_seconds.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/date.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/date.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/date_time_stamp_with_invalid_negative_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/date_time_stamp_with_invalid_negative_offset.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/date_time_stamp_with_invalid_positive_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/date_time_stamp_with_invalid_positive_offset.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/date_time_stamp_with_seconds_in_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/date_time_stamp_with_seconds_in_offset.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/date_time_stamp_with_unexpected_prefix.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/date_time_stamp_with_unexpected_prefix.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/date_time_stamp_with_unexpected_suffix.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/date_time_stamp_with_unexpected_suffix.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/date_time_without_zone.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/date_time_without_zone.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/date_with_time_zone.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/date_with_time_zone.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/empty.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/non_existing_february_29th.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/non_existing_february_29th.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/without_minutes.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/without_minutes.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/without_seconds.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/without_seconds.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Day_time_duration/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Day_time_duration/empty.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Day_time_duration/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Day_time_duration/free_form_text.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Day_time_duration/month.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Day_time_duration/month.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Day_time_duration/negative_days.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Day_time_duration/negative_days.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Day_time_duration/year.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Day_time_duration/year.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Decimal/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Decimal/empty.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Decimal/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Decimal/free_form_text.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Double/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Double/empty.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Double/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Double/free_form_text.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Double/inf_case_matters.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Double/inf_case_matters.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Double/nan_case_matters.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Double/nan_case_matters.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Double/no_fraction_in_scientific_notation.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Double/no_fraction_in_scientific_notation.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Double/plus_inf.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Double/plus_inf.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Double/too_large.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Double/too_large.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Duration/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Duration/empty.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Duration/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Duration/free_form_text.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Duration/integer.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Duration/integer.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Duration/leading_P_missing.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Duration/leading_P_missing.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Duration/negative_years.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Duration/negative_years.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Duration/positive_year_negative_months.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Duration/positive_year_negative_months.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Duration/separator_T_missing.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Duration/separator_T_missing.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Duration/the_order_matters.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Duration/the_order_matters.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Float/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Float/empty.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Float/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Float/free_form_text.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Float/inf_case_matters.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Float/inf_case_matters.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Float/nan_case_matters.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Float/nan_case_matters.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Float/no_fraction_in_scientific_notation.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Float/no_fraction_in_scientific_notation.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Float/plus_inf.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Float/plus_inf.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Float/too_large.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Float/too_large.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_day/day_outside_of_range.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_day/day_outside_of_range.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_day/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_day/empty.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_day/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_day/free_form_text.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_day/invalid_negative_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_day/invalid_negative_offset.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_day/invalid_offset_with_seconds.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_day/invalid_offset_with_seconds.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_day/invalid_positive_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_day/invalid_positive_offset.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_day/missing_leading_dashes.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_day/missing_leading_dashes.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_day/missing_leading_digit.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_day/missing_leading_digit.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_day/unexpected_suffix.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_day/unexpected_suffix.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_month/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_month/empty.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_month/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_month/free_form_text.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_month/invalid_negative_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_month/invalid_negative_offset.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_month/invalid_offset_with_seconds.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_month/invalid_offset_with_seconds.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_month/invalid_positive_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_month/invalid_positive_offset.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_month/missing_leading_dashes.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_month/missing_leading_dashes.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_month/missing_leading_digit.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_month/missing_leading_digit.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_month/month_outside_of_range.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_month/month_outside_of_range.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_month/unexpected_prefix_and_suffix.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_month/unexpected_prefix_and_suffix.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_month_day/day_outside_of_range.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_month_day/day_outside_of_range.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_month_day/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_month_day/empty.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_month_day/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_month_day/free_form_text.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_month_day/invalid_negative_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_month_day/invalid_negative_offset.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_month_day/invalid_offset_with_seconds.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_month_day/invalid_offset_with_seconds.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_month_day/invalid_positive_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_month_day/invalid_positive_offset.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_month_day/missing_leading_dashes.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_month_day/missing_leading_dashes.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_month_day/missing_leading_digit.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_month_day/missing_leading_digit.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_month_day/non_existing_april_31st.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_month_day/non_existing_april_31st.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_month_day/unexpected_prefix_and_suffix.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_month_day/unexpected_prefix_and_suffix.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_year/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_year/empty.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_year/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_year/free_form_text.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_year/invalid_negative_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_year/invalid_negative_offset.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_year/invalid_offset_with_seconds.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_year/invalid_offset_with_seconds.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_year/invalid_positive_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_year/invalid_positive_offset.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_year/missing_century.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_year/missing_century.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_year/unexpected_month.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_year/unexpected_month.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_year_month/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_year_month/empty.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_year_month/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_year_month/free_form_text.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_year_month/invalid_negative_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_year_month/invalid_negative_offset.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_year_month/invalid_offset_with_seconds.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_year_month/invalid_offset_with_seconds.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_year_month/invalid_positive_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_year_month/invalid_positive_offset.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_year_month/missing_century.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_year_month/missing_century.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_year_month/missing_month.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_year_month/missing_month.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_year_month/month_out_of_range.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/G_year_month/month_out_of_range.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Hex_binary/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Hex_binary/free_form_text.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Hex_binary/odd_number_of_digits.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Hex_binary/odd_number_of_digits.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Hex_binary/single_digit.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Hex_binary/single_digit.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Int/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Int/decimal.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Int/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Int/empty.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Int/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Int/free_form_text.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Int/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Int/mathematical_formula.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Int/max_plus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Int/max_plus_one.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Int/min_minus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Int/min_minus_one.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Int/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Int/scientific.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Integer/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Integer/decimal.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Integer/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Integer/empty.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Integer/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Integer/free_form_text.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Integer/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Integer/mathematical_formula.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Integer/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Integer/scientific.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Long/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Long/decimal.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Long/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Long/empty.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Long/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Long/free_form_text.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Long/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Long/mathematical_formula.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Long/max_plus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Long/max_plus_one.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Long/min_minus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Long/min_minus_one.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Long/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Long/scientific.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Negative_integer/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Negative_integer/decimal.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Negative_integer/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Negative_integer/empty.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Negative_integer/explicitly_positive.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Negative_integer/explicitly_positive.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Negative_integer/explicitly_positive_zero.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Negative_integer/explicitly_positive_zero.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Negative_integer/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Negative_integer/free_form_text.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Negative_integer/implicitly_positive.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Negative_integer/implicitly_positive.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Negative_integer/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Negative_integer/mathematical_formula.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Negative_integer/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Negative_integer/scientific.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Negative_integer/zero.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Negative_integer/zero.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Negative_integer/zero_prefixed_with_zeros.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Negative_integer/zero_prefixed_with_zeros.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Non_negative_integer/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Non_negative_integer/decimal.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Non_negative_integer/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Non_negative_integer/empty.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Non_negative_integer/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Non_negative_integer/free_form_text.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Non_negative_integer/negative.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Non_negative_integer/negative.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Non_positive_integer/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Non_positive_integer/decimal.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Non_positive_integer/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Non_positive_integer/empty.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Non_positive_integer/explicitly_positive.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Non_positive_integer/explicitly_positive.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Non_positive_integer/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Non_positive_integer/free_form_text.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Non_positive_integer/implicitly_positive.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Non_positive_integer/implicitly_positive.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Non_positive_integer/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Non_positive_integer/mathematical_formula.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Non_positive_integer/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Non_positive_integer/scientific.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Positive_integer/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Positive_integer/decimal.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Positive_integer/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Positive_integer/empty.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Positive_integer/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Positive_integer/free_form_text.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Positive_integer/negative.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Positive_integer/negative.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Positive_integer/zero.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Positive_integer/zero.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Positive_integer/zero_prefixed_with_zeros.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Positive_integer/zero_prefixed_with_zeros.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Short/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Short/decimal.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Short/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Short/empty.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Short/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Short/free_form_text.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Short/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Short/mathematical_formula.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Short/max_plus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Short/max_plus_one.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Short/min_minus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Short/min_minus_one.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Short/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Short/scientific.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Time/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Time/empty.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Time/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Time/free_form_text.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Time/hour_out_of_range.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Time/hour_out_of_range.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Time/invalid_negative_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Time/invalid_negative_offset.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Time/invalid_offset_with_seconds.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Time/invalid_offset_with_seconds.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Time/invalid_positive_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Time/invalid_positive_offset.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Time/minute_out_of_range.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Time/minute_out_of_range.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Time/missing_padded_zeros.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Time/missing_padded_zeros.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Time/missing_seconds.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Time/missing_seconds.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Time/negative.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Time/negative.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Time/second_out_of_range.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Time/second_out_of_range.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_byte/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_byte/decimal.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_byte/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_byte/empty.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_byte/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_byte/free_form_text.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_byte/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_byte/mathematical_formula.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_byte/max_plus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_byte/max_plus_one.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_byte/negative.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_byte/negative.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_byte/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_byte/scientific.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_int/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_int/decimal.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_int/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_int/empty.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_int/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_int/free_form_text.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_int/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_int/mathematical_formula.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_int/max_plus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_int/max_plus_one.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_int/negative.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_int/negative.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_int/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_int/scientific.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_long/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_long/decimal.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_long/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_long/empty.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_long/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_long/free_form_text.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_long/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_long/mathematical_formula.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_long/max_plus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_long/max_plus_one.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_long/negative.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_long/negative.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_long/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_long/scientific.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_short/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_short/decimal.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_short/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_short/empty.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_short/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_short/free_form_text.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_short/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_short/mathematical_formula.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_short/max_plus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_short/max_plus_one.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_short/negative.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_short/negative.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_short/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Unsigned_short/scientific.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Year_month_duration/day.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Year_month_duration/day.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Year_month_duration/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Year_month_duration/empty.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Year_month_duration/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Year_month_duration/free_form_text.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Year_month_duration/hour_part.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Year_month_duration/hour_part.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Year_month_duration/negative_years.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Year_month_duration/negative_years.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Any_URI/negatively_fuzzed_01.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Any_URI/negatively_fuzzed_01.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Any_URI/negatively_fuzzed_04.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Any_URI/negatively_fuzzed_04.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Any_URI/negatively_fuzzed_05.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Any_URI/negatively_fuzzed_05.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Any_URI/negatively_fuzzed_06.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Any_URI/negatively_fuzzed_06.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Any_URI/negatively_fuzzed_10.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Any_URI/negatively_fuzzed_10.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Any_URI/percentage_followed_by_non_two_hexadecimal_digits.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Any_URI/percentage_followed_by_non_two_hexadecimal_digits.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Any_URI/too_many_fragments.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Any_URI/too_many_fragments.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Base_64_binary/an_odd_number_of_characters_is_not_valid.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Base_64_binary/an_odd_number_of_characters_is_not_valid.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Base_64_binary/equals_signs_may_only_appear_at_the_end.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Base_64_binary/equals_signs_may_only_appear_at_the_end.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Base_64_binary/negatively_fuzzed_03.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Base_64_binary/negatively_fuzzed_03.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Base_64_binary/negatively_fuzzed_04.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Base_64_binary/negatively_fuzzed_04.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Base_64_binary/negatively_fuzzed_05.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Base_64_binary/negatively_fuzzed_05.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Base_64_binary/negatively_fuzzed_06.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Base_64_binary/negatively_fuzzed_06.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Base_64_binary/negatively_fuzzed_08.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Base_64_binary/negatively_fuzzed_08.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Base_64_binary/negatively_fuzzed_10.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Base_64_binary/negatively_fuzzed_10.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Boolean/false_as_number_with_leading_zeros.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Boolean/false_as_number_with_leading_zeros.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Boolean/false_in_camelcase.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Boolean/false_in_camelcase.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Boolean/false_in_uppercase.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Boolean/false_in_uppercase.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Boolean/negatively_fuzzed_01.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Boolean/negatively_fuzzed_01.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Boolean/negatively_fuzzed_03.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Boolean/negatively_fuzzed_03.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Boolean/negatively_fuzzed_05.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Boolean/negatively_fuzzed_05.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Boolean/negatively_fuzzed_10.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Boolean/negatively_fuzzed_10.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Boolean/true_as_number_with_leading_zeros.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Boolean/true_as_number_with_leading_zeros.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Boolean/true_in_camelcase.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Boolean/true_in_camelcase.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Boolean/true_in_uppercase.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Boolean/true_in_uppercase.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Byte/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Byte/decimal.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Byte/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Byte/empty.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Byte/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Byte/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Byte/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Byte/mathematical_formula.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Byte/max_plus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Byte/max_plus_one.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Byte/min_minus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Byte/min_minus_one.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Byte/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Byte/scientific.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date/date_time_with_UTC.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date/date_time_with_UTC.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date/date_time_with_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date/date_time_with_offset.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date/date_time_without_zone.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date/date_time_without_zone.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date/date_with_invalid_negative_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date/date_with_invalid_negative_offset.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date/date_with_invalid_positive_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date/date_with_invalid_positive_offset.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date/date_with_seconds_in_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date/date_with_seconds_in_offset.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date/empty.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date/non_existing_february_29th.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date/non_existing_february_29th.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/date.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/date.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/date_time_with_invalid_negative_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/date_time_with_invalid_negative_offset.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/date_time_with_invalid_positive_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/date_time_with_invalid_positive_offset.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/date_time_with_seconds_in_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/date_time_with_seconds_in_offset.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/date_time_with_unexpected_prefix.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/date_time_with_unexpected_prefix.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/date_time_with_unexpected_suffix.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/date_time_with_unexpected_suffix.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/date_with_time_zone.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/date_with_time_zone.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/empty.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/non_existing_february_29th.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/non_existing_february_29th.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/without_minutes.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/without_minutes.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/without_seconds.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/without_seconds.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/date.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/date.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/date_time_stamp_with_invalid_negative_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/date_time_stamp_with_invalid_negative_offset.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/date_time_stamp_with_invalid_positive_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/date_time_stamp_with_invalid_positive_offset.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/date_time_stamp_with_seconds_in_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/date_time_stamp_with_seconds_in_offset.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/date_time_stamp_with_unexpected_prefix.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/date_time_stamp_with_unexpected_prefix.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/date_time_stamp_with_unexpected_suffix.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/date_time_stamp_with_unexpected_suffix.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/date_time_without_zone.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/date_time_without_zone.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/date_with_time_zone.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/date_with_time_zone.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/empty.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/non_existing_february_29th.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/non_existing_february_29th.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/without_minutes.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/without_minutes.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/without_seconds.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/without_seconds.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Day_time_duration/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Day_time_duration/empty.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Day_time_duration/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Day_time_duration/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Day_time_duration/month.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Day_time_duration/month.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Day_time_duration/negative_days.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Day_time_duration/negative_days.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Day_time_duration/year.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Day_time_duration/year.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Decimal/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Decimal/empty.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Decimal/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Decimal/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Double/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Double/empty.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Double/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Double/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Double/inf_case_matters.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Double/inf_case_matters.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Double/nan_case_matters.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Double/nan_case_matters.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Double/no_fraction_in_scientific_notation.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Double/no_fraction_in_scientific_notation.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Double/plus_inf.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Double/plus_inf.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Double/too_large.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Double/too_large.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Duration/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Duration/empty.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Duration/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Duration/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Duration/integer.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Duration/integer.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Duration/leading_P_missing.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Duration/leading_P_missing.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Duration/negative_years.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Duration/negative_years.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Duration/positive_year_negative_months.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Duration/positive_year_negative_months.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Duration/separator_T_missing.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Duration/separator_T_missing.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Duration/the_order_matters.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Duration/the_order_matters.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Float/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Float/empty.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Float/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Float/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Float/inf_case_matters.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Float/inf_case_matters.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Float/nan_case_matters.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Float/nan_case_matters.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Float/no_fraction_in_scientific_notation.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Float/no_fraction_in_scientific_notation.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Float/plus_inf.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Float/plus_inf.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Float/too_large.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Float/too_large.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_day/day_outside_of_range.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_day/day_outside_of_range.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_day/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_day/empty.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_day/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_day/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_day/invalid_negative_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_day/invalid_negative_offset.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_day/invalid_offset_with_seconds.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_day/invalid_offset_with_seconds.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_day/invalid_positive_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_day/invalid_positive_offset.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_day/missing_leading_dashes.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_day/missing_leading_dashes.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_day/missing_leading_digit.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_day/missing_leading_digit.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_day/unexpected_suffix.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_day/unexpected_suffix.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_month/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_month/empty.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_month/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_month/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_month/invalid_negative_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_month/invalid_negative_offset.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_month/invalid_offset_with_seconds.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_month/invalid_offset_with_seconds.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_month/invalid_positive_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_month/invalid_positive_offset.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_month/missing_leading_dashes.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_month/missing_leading_dashes.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_month/missing_leading_digit.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_month/missing_leading_digit.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_month/month_outside_of_range.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_month/month_outside_of_range.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_month/unexpected_prefix_and_suffix.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_month/unexpected_prefix_and_suffix.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_month_day/day_outside_of_range.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_month_day/day_outside_of_range.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_month_day/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_month_day/empty.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_month_day/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_month_day/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_month_day/invalid_negative_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_month_day/invalid_negative_offset.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_month_day/invalid_offset_with_seconds.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_month_day/invalid_offset_with_seconds.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_month_day/invalid_positive_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_month_day/invalid_positive_offset.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_month_day/missing_leading_dashes.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_month_day/missing_leading_dashes.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_month_day/missing_leading_digit.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_month_day/missing_leading_digit.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_month_day/non_existing_april_31st.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_month_day/non_existing_april_31st.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_month_day/unexpected_prefix_and_suffix.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_month_day/unexpected_prefix_and_suffix.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_year/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_year/empty.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_year/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_year/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_year/invalid_negative_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_year/invalid_negative_offset.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_year/invalid_offset_with_seconds.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_year/invalid_offset_with_seconds.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_year/invalid_positive_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_year/invalid_positive_offset.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_year/missing_century.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_year/missing_century.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_year/unexpected_month.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_year/unexpected_month.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_year_month/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_year_month/empty.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_year_month/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_year_month/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_year_month/invalid_negative_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_year_month/invalid_negative_offset.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_year_month/invalid_offset_with_seconds.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_year_month/invalid_offset_with_seconds.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_year_month/invalid_positive_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_year_month/invalid_positive_offset.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_year_month/missing_century.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_year_month/missing_century.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_year_month/missing_month.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_year_month/missing_month.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_year_month/month_out_of_range.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/G_year_month/month_out_of_range.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Hex_binary/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Hex_binary/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Hex_binary/odd_number_of_digits.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Hex_binary/odd_number_of_digits.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Hex_binary/single_digit.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Hex_binary/single_digit.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Int/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Int/decimal.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Int/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Int/empty.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Int/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Int/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Int/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Int/mathematical_formula.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Int/max_plus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Int/max_plus_one.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Int/min_minus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Int/min_minus_one.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Int/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Int/scientific.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Integer/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Integer/decimal.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Integer/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Integer/empty.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Integer/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Integer/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Integer/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Integer/mathematical_formula.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Integer/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Integer/scientific.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Long/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Long/decimal.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Long/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Long/empty.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Long/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Long/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Long/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Long/mathematical_formula.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Long/max_plus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Long/max_plus_one.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Long/min_minus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Long/min_minus_one.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Long/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Long/scientific.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Negative_integer/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Negative_integer/decimal.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Negative_integer/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Negative_integer/empty.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Negative_integer/explicitly_positive.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Negative_integer/explicitly_positive.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Negative_integer/explicitly_positive_zero.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Negative_integer/explicitly_positive_zero.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Negative_integer/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Negative_integer/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Negative_integer/implicitly_positive.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Negative_integer/implicitly_positive.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Negative_integer/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Negative_integer/mathematical_formula.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Negative_integer/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Negative_integer/scientific.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Negative_integer/zero.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Negative_integer/zero.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Negative_integer/zero_prefixed_with_zeros.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Negative_integer/zero_prefixed_with_zeros.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Non_negative_integer/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Non_negative_integer/decimal.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Non_negative_integer/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Non_negative_integer/empty.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Non_negative_integer/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Non_negative_integer/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Non_negative_integer/negative.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Non_negative_integer/negative.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Non_positive_integer/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Non_positive_integer/decimal.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Non_positive_integer/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Non_positive_integer/empty.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Non_positive_integer/explicitly_positive.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Non_positive_integer/explicitly_positive.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Non_positive_integer/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Non_positive_integer/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Non_positive_integer/implicitly_positive.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Non_positive_integer/implicitly_positive.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Non_positive_integer/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Non_positive_integer/mathematical_formula.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Non_positive_integer/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Non_positive_integer/scientific.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Positive_integer/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Positive_integer/decimal.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Positive_integer/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Positive_integer/empty.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Positive_integer/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Positive_integer/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Positive_integer/negative.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Positive_integer/negative.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Positive_integer/zero.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Positive_integer/zero.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Positive_integer/zero_prefixed_with_zeros.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Positive_integer/zero_prefixed_with_zeros.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Short/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Short/decimal.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Short/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Short/empty.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Short/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Short/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Short/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Short/mathematical_formula.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Short/max_plus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Short/max_plus_one.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Short/min_minus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Short/min_minus_one.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Short/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Short/scientific.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Time/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Time/empty.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Time/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Time/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Time/hour_out_of_range.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Time/hour_out_of_range.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Time/invalid_negative_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Time/invalid_negative_offset.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Time/invalid_offset_with_seconds.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Time/invalid_offset_with_seconds.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Time/invalid_positive_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Time/invalid_positive_offset.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Time/minute_out_of_range.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Time/minute_out_of_range.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Time/missing_padded_zeros.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Time/missing_padded_zeros.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Time/missing_seconds.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Time/missing_seconds.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Time/negative.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Time/negative.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Time/second_out_of_range.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Time/second_out_of_range.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_byte/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_byte/decimal.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_byte/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_byte/empty.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_byte/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_byte/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_byte/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_byte/mathematical_formula.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_byte/max_plus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_byte/max_plus_one.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_byte/negative.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_byte/negative.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_byte/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_byte/scientific.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_int/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_int/decimal.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_int/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_int/empty.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_int/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_int/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_int/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_int/mathematical_formula.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_int/max_plus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_int/max_plus_one.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_int/negative.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_int/negative.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_int/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_int/scientific.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_long/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_long/decimal.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_long/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_long/empty.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_long/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_long/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_long/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_long/mathematical_formula.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_long/max_plus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_long/max_plus_one.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_long/negative.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_long/negative.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_long/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_long/scientific.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_short/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_short/decimal.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_short/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_short/empty.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_short/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_short/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_short/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_short/mathematical_formula.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_short/max_plus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_short/max_plus_one.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_short/negative.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_short/negative.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_short/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Unsigned_short/scientific.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Year_month_duration/day.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Year_month_duration/day.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Year_month_duration/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Year_month_duration/empty.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Year_month_duration/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Year_month_duration/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Year_month_duration/hour_part.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Year_month_duration/hour_part.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Year_month_duration/negative_years.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Year_month_duration/negative_years.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Any_URI/negatively_fuzzed_01.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Any_URI/negatively_fuzzed_01.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Any_URI/negatively_fuzzed_04.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Any_URI/negatively_fuzzed_04.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Any_URI/negatively_fuzzed_05.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Any_URI/negatively_fuzzed_05.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Any_URI/negatively_fuzzed_06.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Any_URI/negatively_fuzzed_06.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Any_URI/negatively_fuzzed_10.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Any_URI/negatively_fuzzed_10.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Any_URI/percentage_followed_by_non_two_hexadecimal_digits.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Any_URI/percentage_followed_by_non_two_hexadecimal_digits.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Any_URI/too_many_fragments.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Any_URI/too_many_fragments.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Base_64_binary/an_odd_number_of_characters_is_not_valid.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Base_64_binary/an_odd_number_of_characters_is_not_valid.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Base_64_binary/equals_signs_may_only_appear_at_the_end.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Base_64_binary/equals_signs_may_only_appear_at_the_end.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Base_64_binary/negatively_fuzzed_03.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Base_64_binary/negatively_fuzzed_03.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Base_64_binary/negatively_fuzzed_04.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Base_64_binary/negatively_fuzzed_04.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Base_64_binary/negatively_fuzzed_05.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Base_64_binary/negatively_fuzzed_05.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Base_64_binary/negatively_fuzzed_06.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Base_64_binary/negatively_fuzzed_06.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Base_64_binary/negatively_fuzzed_08.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Base_64_binary/negatively_fuzzed_08.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Base_64_binary/negatively_fuzzed_10.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Base_64_binary/negatively_fuzzed_10.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Boolean/false_as_number_with_leading_zeros.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Boolean/false_as_number_with_leading_zeros.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Boolean/false_in_camelcase.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Boolean/false_in_camelcase.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Boolean/false_in_uppercase.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Boolean/false_in_uppercase.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Boolean/negatively_fuzzed_01.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Boolean/negatively_fuzzed_01.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Boolean/negatively_fuzzed_03.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Boolean/negatively_fuzzed_03.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Boolean/negatively_fuzzed_05.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Boolean/negatively_fuzzed_05.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Boolean/negatively_fuzzed_10.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Boolean/negatively_fuzzed_10.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Boolean/true_as_number_with_leading_zeros.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Boolean/true_as_number_with_leading_zeros.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Boolean/true_in_camelcase.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Boolean/true_in_camelcase.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Boolean/true_in_uppercase.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Boolean/true_in_uppercase.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Byte/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Byte/decimal.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Byte/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Byte/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Byte/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Byte/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Byte/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Byte/mathematical_formula.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Byte/max_plus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Byte/max_plus_one.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Byte/min_minus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Byte/min_minus_one.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Byte/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Byte/scientific.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date/date_time_with_UTC.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date/date_time_with_UTC.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date/date_time_with_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date/date_time_with_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date/date_time_without_zone.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date/date_time_without_zone.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date/date_with_invalid_negative_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date/date_with_invalid_negative_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date/date_with_invalid_positive_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date/date_with_invalid_positive_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date/date_with_seconds_in_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date/date_with_seconds_in_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date/non_existing_february_29th.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date/non_existing_february_29th.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/date.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/date.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/date_time_with_invalid_negative_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/date_time_with_invalid_negative_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/date_time_with_invalid_positive_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/date_time_with_invalid_positive_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/date_time_with_seconds_in_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/date_time_with_seconds_in_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/date_time_with_unexpected_prefix.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/date_time_with_unexpected_prefix.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/date_time_with_unexpected_suffix.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/date_time_with_unexpected_suffix.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/date_with_time_zone.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/date_with_time_zone.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/non_existing_february_29th.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/non_existing_february_29th.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/without_minutes.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/without_minutes.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/without_seconds.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/without_seconds.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/date.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/date.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/date_time_stamp_with_invalid_negative_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/date_time_stamp_with_invalid_negative_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/date_time_stamp_with_invalid_positive_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/date_time_stamp_with_invalid_positive_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/date_time_stamp_with_seconds_in_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/date_time_stamp_with_seconds_in_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/date_time_stamp_with_unexpected_prefix.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/date_time_stamp_with_unexpected_prefix.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/date_time_stamp_with_unexpected_suffix.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/date_time_stamp_with_unexpected_suffix.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/date_time_without_zone.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/date_time_without_zone.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/date_with_time_zone.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/date_with_time_zone.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/non_existing_february_29th.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/non_existing_february_29th.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/without_minutes.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/without_minutes.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/without_seconds.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/without_seconds.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Day_time_duration/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Day_time_duration/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Day_time_duration/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Day_time_duration/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Day_time_duration/month.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Day_time_duration/month.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Day_time_duration/negative_days.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Day_time_duration/negative_days.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Day_time_duration/year.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Day_time_duration/year.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Decimal/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Decimal/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Decimal/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Decimal/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Double/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Double/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Double/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Double/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Double/inf_case_matters.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Double/inf_case_matters.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Double/nan_case_matters.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Double/nan_case_matters.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Double/no_fraction_in_scientific_notation.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Double/no_fraction_in_scientific_notation.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Double/plus_inf.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Double/plus_inf.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Double/too_large.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Double/too_large.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Duration/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Duration/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Duration/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Duration/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Duration/integer.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Duration/integer.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Duration/leading_P_missing.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Duration/leading_P_missing.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Duration/negative_years.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Duration/negative_years.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Duration/positive_year_negative_months.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Duration/positive_year_negative_months.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Duration/separator_T_missing.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Duration/separator_T_missing.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Duration/the_order_matters.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Duration/the_order_matters.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Float/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Float/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Float/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Float/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Float/inf_case_matters.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Float/inf_case_matters.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Float/nan_case_matters.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Float/nan_case_matters.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Float/no_fraction_in_scientific_notation.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Float/no_fraction_in_scientific_notation.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Float/plus_inf.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Float/plus_inf.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Float/too_large.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Float/too_large.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_day/day_outside_of_range.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_day/day_outside_of_range.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_day/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_day/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_day/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_day/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_day/invalid_negative_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_day/invalid_negative_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_day/invalid_offset_with_seconds.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_day/invalid_offset_with_seconds.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_day/invalid_positive_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_day/invalid_positive_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_day/missing_leading_dashes.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_day/missing_leading_dashes.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_day/missing_leading_digit.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_day/missing_leading_digit.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_day/unexpected_suffix.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_day/unexpected_suffix.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_month/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_month/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_month/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_month/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_month/invalid_negative_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_month/invalid_negative_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_month/invalid_offset_with_seconds.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_month/invalid_offset_with_seconds.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_month/invalid_positive_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_month/invalid_positive_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_month/missing_leading_dashes.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_month/missing_leading_dashes.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_month/missing_leading_digit.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_month/missing_leading_digit.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_month/month_outside_of_range.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_month/month_outside_of_range.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_month/unexpected_prefix_and_suffix.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_month/unexpected_prefix_and_suffix.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_month_day/day_outside_of_range.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_month_day/day_outside_of_range.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_month_day/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_month_day/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_month_day/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_month_day/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_month_day/invalid_negative_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_month_day/invalid_negative_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_month_day/invalid_offset_with_seconds.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_month_day/invalid_offset_with_seconds.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_month_day/invalid_positive_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_month_day/invalid_positive_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_month_day/missing_leading_dashes.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_month_day/missing_leading_dashes.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_month_day/missing_leading_digit.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_month_day/missing_leading_digit.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_month_day/non_existing_april_31st.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_month_day/non_existing_april_31st.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_month_day/unexpected_prefix_and_suffix.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_month_day/unexpected_prefix_and_suffix.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_year/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_year/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_year/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_year/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_year/invalid_negative_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_year/invalid_negative_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_year/invalid_offset_with_seconds.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_year/invalid_offset_with_seconds.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_year/invalid_positive_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_year/invalid_positive_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_year/missing_century.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_year/missing_century.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_year/unexpected_month.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_year/unexpected_month.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_year_month/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_year_month/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_year_month/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_year_month/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_year_month/invalid_negative_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_year_month/invalid_negative_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_year_month/invalid_offset_with_seconds.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_year_month/invalid_offset_with_seconds.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_year_month/invalid_positive_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_year_month/invalid_positive_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_year_month/missing_century.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_year_month/missing_century.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_year_month/missing_month.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_year_month/missing_month.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_year_month/month_out_of_range.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/G_year_month/month_out_of_range.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Hex_binary/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Hex_binary/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Hex_binary/odd_number_of_digits.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Hex_binary/odd_number_of_digits.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Hex_binary/single_digit.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Hex_binary/single_digit.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Int/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Int/decimal.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Int/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Int/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Int/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Int/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Int/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Int/mathematical_formula.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Int/max_plus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Int/max_plus_one.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Int/min_minus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Int/min_minus_one.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Int/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Int/scientific.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Integer/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Integer/decimal.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Integer/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Integer/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Integer/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Integer/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Integer/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Integer/mathematical_formula.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Integer/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Integer/scientific.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Long/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Long/decimal.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Long/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Long/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Long/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Long/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Long/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Long/mathematical_formula.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Long/max_plus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Long/max_plus_one.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Long/min_minus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Long/min_minus_one.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Long/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Long/scientific.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Negative_integer/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Negative_integer/decimal.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Negative_integer/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Negative_integer/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Negative_integer/explicitly_positive.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Negative_integer/explicitly_positive.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Negative_integer/explicitly_positive_zero.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Negative_integer/explicitly_positive_zero.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Negative_integer/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Negative_integer/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Negative_integer/implicitly_positive.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Negative_integer/implicitly_positive.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Negative_integer/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Negative_integer/mathematical_formula.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Negative_integer/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Negative_integer/scientific.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Negative_integer/zero.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Negative_integer/zero.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Negative_integer/zero_prefixed_with_zeros.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Negative_integer/zero_prefixed_with_zeros.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Non_negative_integer/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Non_negative_integer/decimal.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Non_negative_integer/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Non_negative_integer/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Non_negative_integer/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Non_negative_integer/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Non_negative_integer/negative.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Non_negative_integer/negative.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Non_positive_integer/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Non_positive_integer/decimal.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Non_positive_integer/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Non_positive_integer/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Non_positive_integer/explicitly_positive.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Non_positive_integer/explicitly_positive.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Non_positive_integer/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Non_positive_integer/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Non_positive_integer/implicitly_positive.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Non_positive_integer/implicitly_positive.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Non_positive_integer/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Non_positive_integer/mathematical_formula.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Non_positive_integer/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Non_positive_integer/scientific.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Positive_integer/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Positive_integer/decimal.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Positive_integer/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Positive_integer/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Positive_integer/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Positive_integer/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Positive_integer/negative.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Positive_integer/negative.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Positive_integer/zero.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Positive_integer/zero.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Positive_integer/zero_prefixed_with_zeros.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Positive_integer/zero_prefixed_with_zeros.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Short/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Short/decimal.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Short/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Short/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Short/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Short/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Short/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Short/mathematical_formula.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Short/max_plus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Short/max_plus_one.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Short/min_minus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Short/min_minus_one.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Short/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Short/scientific.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Time/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Time/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Time/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Time/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Time/hour_out_of_range.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Time/hour_out_of_range.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Time/invalid_negative_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Time/invalid_negative_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Time/invalid_offset_with_seconds.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Time/invalid_offset_with_seconds.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Time/invalid_positive_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Time/invalid_positive_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Time/minute_out_of_range.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Time/minute_out_of_range.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Time/missing_padded_zeros.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Time/missing_padded_zeros.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Time/missing_seconds.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Time/missing_seconds.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Time/negative.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Time/negative.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Time/second_out_of_range.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Time/second_out_of_range.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_byte/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_byte/decimal.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_byte/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_byte/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_byte/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_byte/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_byte/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_byte/mathematical_formula.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_byte/max_plus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_byte/max_plus_one.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_byte/negative.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_byte/negative.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_byte/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_byte/scientific.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_int/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_int/decimal.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_int/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_int/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_int/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_int/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_int/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_int/mathematical_formula.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_int/max_plus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_int/max_plus_one.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_int/negative.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_int/negative.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_int/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_int/scientific.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_long/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_long/decimal.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_long/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_long/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_long/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_long/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_long/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_long/mathematical_formula.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_long/max_plus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_long/max_plus_one.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_long/negative.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_long/negative.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_long/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_long/scientific.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_short/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_short/decimal.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_short/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_short/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_short/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_short/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_short/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_short/mathematical_formula.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_short/max_plus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_short/max_plus_one.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_short/negative.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_short/negative.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_short/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Unsigned_short/scientific.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Year_month_duration/day.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Year_month_duration/day.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Year_month_duration/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Year_month_duration/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Year_month_duration/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Year_month_duration/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Year_month_duration/hour_part.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Year_month_duration/hour_part.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Year_month_duration/negative_years.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Year_month_duration/negative_years.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Any_URI/negatively_fuzzed_01.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Any_URI/negatively_fuzzed_01.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Any_URI/negatively_fuzzed_04.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Any_URI/negatively_fuzzed_04.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Any_URI/negatively_fuzzed_05.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Any_URI/negatively_fuzzed_05.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Any_URI/negatively_fuzzed_06.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Any_URI/negatively_fuzzed_06.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Any_URI/negatively_fuzzed_10.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Any_URI/negatively_fuzzed_10.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Any_URI/percentage_followed_by_non_two_hexadecimal_digits.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Any_URI/percentage_followed_by_non_two_hexadecimal_digits.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Any_URI/too_many_fragments.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Any_URI/too_many_fragments.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Base_64_binary/an_odd_number_of_characters_is_not_valid.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Base_64_binary/an_odd_number_of_characters_is_not_valid.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Base_64_binary/equals_signs_may_only_appear_at_the_end.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Base_64_binary/equals_signs_may_only_appear_at_the_end.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Base_64_binary/negatively_fuzzed_03.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Base_64_binary/negatively_fuzzed_03.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Base_64_binary/negatively_fuzzed_04.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Base_64_binary/negatively_fuzzed_04.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Base_64_binary/negatively_fuzzed_05.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Base_64_binary/negatively_fuzzed_05.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Base_64_binary/negatively_fuzzed_06.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Base_64_binary/negatively_fuzzed_06.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Base_64_binary/negatively_fuzzed_08.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Base_64_binary/negatively_fuzzed_08.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Base_64_binary/negatively_fuzzed_10.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Base_64_binary/negatively_fuzzed_10.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Boolean/false_as_number_with_leading_zeros.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Boolean/false_as_number_with_leading_zeros.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Boolean/false_in_camelcase.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Boolean/false_in_camelcase.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Boolean/false_in_uppercase.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Boolean/false_in_uppercase.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Boolean/negatively_fuzzed_01.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Boolean/negatively_fuzzed_01.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Boolean/negatively_fuzzed_03.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Boolean/negatively_fuzzed_03.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Boolean/negatively_fuzzed_05.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Boolean/negatively_fuzzed_05.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Boolean/negatively_fuzzed_10.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Boolean/negatively_fuzzed_10.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Boolean/true_as_number_with_leading_zeros.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Boolean/true_as_number_with_leading_zeros.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Boolean/true_in_camelcase.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Boolean/true_in_camelcase.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Boolean/true_in_uppercase.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Boolean/true_in_uppercase.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Byte/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Byte/decimal.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Byte/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Byte/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Byte/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Byte/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Byte/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Byte/mathematical_formula.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Byte/max_plus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Byte/max_plus_one.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Byte/min_minus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Byte/min_minus_one.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Byte/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Byte/scientific.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date/date_time_with_UTC.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date/date_time_with_UTC.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date/date_time_with_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date/date_time_with_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date/date_time_without_zone.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date/date_time_without_zone.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date/date_with_invalid_negative_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date/date_with_invalid_negative_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date/date_with_invalid_positive_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date/date_with_invalid_positive_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date/date_with_seconds_in_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date/date_with_seconds_in_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date/non_existing_february_29th.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date/non_existing_february_29th.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/date.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/date.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/date_time_with_invalid_negative_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/date_time_with_invalid_negative_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/date_time_with_invalid_positive_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/date_time_with_invalid_positive_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/date_time_with_seconds_in_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/date_time_with_seconds_in_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/date_time_with_unexpected_prefix.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/date_time_with_unexpected_prefix.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/date_time_with_unexpected_suffix.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/date_time_with_unexpected_suffix.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/date_with_time_zone.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/date_with_time_zone.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/non_existing_february_29th.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/non_existing_february_29th.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/without_minutes.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/without_minutes.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/without_seconds.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/without_seconds.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/date.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/date.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/date_time_stamp_with_invalid_negative_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/date_time_stamp_with_invalid_negative_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/date_time_stamp_with_invalid_positive_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/date_time_stamp_with_invalid_positive_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/date_time_stamp_with_seconds_in_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/date_time_stamp_with_seconds_in_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/date_time_stamp_with_unexpected_prefix.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/date_time_stamp_with_unexpected_prefix.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/date_time_stamp_with_unexpected_suffix.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/date_time_stamp_with_unexpected_suffix.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/date_time_without_zone.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/date_time_without_zone.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/date_with_time_zone.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/date_with_time_zone.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/non_existing_february_29th.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/non_existing_february_29th.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/without_minutes.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/without_minutes.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/without_seconds.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/without_seconds.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Day_time_duration/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Day_time_duration/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Day_time_duration/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Day_time_duration/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Day_time_duration/month.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Day_time_duration/month.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Day_time_duration/negative_days.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Day_time_duration/negative_days.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Day_time_duration/year.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Day_time_duration/year.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Decimal/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Decimal/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Decimal/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Decimal/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Double/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Double/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Double/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Double/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Double/inf_case_matters.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Double/inf_case_matters.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Double/nan_case_matters.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Double/nan_case_matters.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Double/no_fraction_in_scientific_notation.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Double/no_fraction_in_scientific_notation.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Double/plus_inf.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Double/plus_inf.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Double/too_large.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Double/too_large.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Duration/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Duration/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Duration/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Duration/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Duration/integer.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Duration/integer.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Duration/leading_P_missing.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Duration/leading_P_missing.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Duration/negative_years.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Duration/negative_years.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Duration/positive_year_negative_months.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Duration/positive_year_negative_months.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Duration/separator_T_missing.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Duration/separator_T_missing.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Duration/the_order_matters.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Duration/the_order_matters.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Float/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Float/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Float/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Float/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Float/inf_case_matters.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Float/inf_case_matters.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Float/nan_case_matters.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Float/nan_case_matters.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Float/no_fraction_in_scientific_notation.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Float/no_fraction_in_scientific_notation.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Float/plus_inf.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Float/plus_inf.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Float/too_large.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Float/too_large.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_day/day_outside_of_range.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_day/day_outside_of_range.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_day/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_day/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_day/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_day/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_day/invalid_negative_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_day/invalid_negative_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_day/invalid_offset_with_seconds.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_day/invalid_offset_with_seconds.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_day/invalid_positive_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_day/invalid_positive_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_day/missing_leading_dashes.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_day/missing_leading_dashes.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_day/missing_leading_digit.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_day/missing_leading_digit.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_day/unexpected_suffix.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_day/unexpected_suffix.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_month/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_month/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_month/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_month/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_month/invalid_negative_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_month/invalid_negative_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_month/invalid_offset_with_seconds.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_month/invalid_offset_with_seconds.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_month/invalid_positive_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_month/invalid_positive_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_month/missing_leading_dashes.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_month/missing_leading_dashes.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_month/missing_leading_digit.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_month/missing_leading_digit.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_month/month_outside_of_range.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_month/month_outside_of_range.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_month/unexpected_prefix_and_suffix.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_month/unexpected_prefix_and_suffix.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_month_day/day_outside_of_range.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_month_day/day_outside_of_range.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_month_day/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_month_day/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_month_day/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_month_day/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_month_day/invalid_negative_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_month_day/invalid_negative_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_month_day/invalid_offset_with_seconds.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_month_day/invalid_offset_with_seconds.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_month_day/invalid_positive_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_month_day/invalid_positive_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_month_day/missing_leading_dashes.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_month_day/missing_leading_dashes.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_month_day/missing_leading_digit.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_month_day/missing_leading_digit.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_month_day/non_existing_april_31st.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_month_day/non_existing_april_31st.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_month_day/unexpected_prefix_and_suffix.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_month_day/unexpected_prefix_and_suffix.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_year/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_year/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_year/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_year/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_year/invalid_negative_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_year/invalid_negative_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_year/invalid_offset_with_seconds.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_year/invalid_offset_with_seconds.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_year/invalid_positive_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_year/invalid_positive_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_year/missing_century.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_year/missing_century.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_year/unexpected_month.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_year/unexpected_month.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_year_month/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_year_month/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_year_month/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_year_month/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_year_month/invalid_negative_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_year_month/invalid_negative_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_year_month/invalid_offset_with_seconds.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_year_month/invalid_offset_with_seconds.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_year_month/invalid_positive_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_year_month/invalid_positive_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_year_month/missing_century.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_year_month/missing_century.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_year_month/missing_month.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_year_month/missing_month.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_year_month/month_out_of_range.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/G_year_month/month_out_of_range.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Hex_binary/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Hex_binary/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Hex_binary/odd_number_of_digits.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Hex_binary/odd_number_of_digits.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Hex_binary/single_digit.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Hex_binary/single_digit.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Int/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Int/decimal.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Int/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Int/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Int/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Int/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Int/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Int/mathematical_formula.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Int/max_plus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Int/max_plus_one.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Int/min_minus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Int/min_minus_one.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Int/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Int/scientific.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Integer/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Integer/decimal.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Integer/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Integer/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Integer/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Integer/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Integer/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Integer/mathematical_formula.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Integer/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Integer/scientific.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Long/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Long/decimal.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Long/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Long/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Long/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Long/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Long/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Long/mathematical_formula.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Long/max_plus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Long/max_plus_one.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Long/min_minus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Long/min_minus_one.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Long/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Long/scientific.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Negative_integer/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Negative_integer/decimal.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Negative_integer/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Negative_integer/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Negative_integer/explicitly_positive.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Negative_integer/explicitly_positive.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Negative_integer/explicitly_positive_zero.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Negative_integer/explicitly_positive_zero.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Negative_integer/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Negative_integer/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Negative_integer/implicitly_positive.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Negative_integer/implicitly_positive.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Negative_integer/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Negative_integer/mathematical_formula.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Negative_integer/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Negative_integer/scientific.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Negative_integer/zero.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Negative_integer/zero.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Negative_integer/zero_prefixed_with_zeros.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Negative_integer/zero_prefixed_with_zeros.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Non_negative_integer/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Non_negative_integer/decimal.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Non_negative_integer/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Non_negative_integer/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Non_negative_integer/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Non_negative_integer/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Non_negative_integer/negative.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Non_negative_integer/negative.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Non_positive_integer/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Non_positive_integer/decimal.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Non_positive_integer/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Non_positive_integer/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Non_positive_integer/explicitly_positive.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Non_positive_integer/explicitly_positive.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Non_positive_integer/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Non_positive_integer/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Non_positive_integer/implicitly_positive.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Non_positive_integer/implicitly_positive.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Non_positive_integer/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Non_positive_integer/mathematical_formula.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Non_positive_integer/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Non_positive_integer/scientific.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Positive_integer/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Positive_integer/decimal.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Positive_integer/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Positive_integer/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Positive_integer/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Positive_integer/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Positive_integer/negative.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Positive_integer/negative.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Positive_integer/zero.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Positive_integer/zero.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Positive_integer/zero_prefixed_with_zeros.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Positive_integer/zero_prefixed_with_zeros.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Short/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Short/decimal.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Short/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Short/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Short/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Short/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Short/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Short/mathematical_formula.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Short/max_plus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Short/max_plus_one.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Short/min_minus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Short/min_minus_one.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Short/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Short/scientific.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Time/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Time/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Time/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Time/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Time/hour_out_of_range.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Time/hour_out_of_range.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Time/invalid_negative_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Time/invalid_negative_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Time/invalid_offset_with_seconds.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Time/invalid_offset_with_seconds.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Time/invalid_positive_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Time/invalid_positive_offset.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Time/minute_out_of_range.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Time/minute_out_of_range.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Time/missing_padded_zeros.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Time/missing_padded_zeros.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Time/missing_seconds.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Time/missing_seconds.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Time/negative.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Time/negative.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Time/second_out_of_range.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Time/second_out_of_range.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_byte/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_byte/decimal.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_byte/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_byte/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_byte/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_byte/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_byte/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_byte/mathematical_formula.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_byte/max_plus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_byte/max_plus_one.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_byte/negative.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_byte/negative.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_byte/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_byte/scientific.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_int/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_int/decimal.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_int/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_int/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_int/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_int/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_int/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_int/mathematical_formula.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_int/max_plus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_int/max_plus_one.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_int/negative.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_int/negative.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_int/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_int/scientific.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_long/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_long/decimal.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_long/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_long/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_long/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_long/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_long/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_long/mathematical_formula.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_long/max_plus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_long/max_plus_one.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_long/negative.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_long/negative.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_long/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_long/scientific.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_short/decimal.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_short/decimal.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_short/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_short/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_short/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_short/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_short/mathematical_formula.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_short/mathematical_formula.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_short/max_plus_one.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_short/max_plus_one.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_short/negative.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_short/negative.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_short/scientific.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Unsigned_short/scientific.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Year_month_duration/day.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Year_month_duration/day.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Year_month_duration/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Year_month_duration/empty.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Year_month_duration/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Year_month_duration/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Year_month_duration/hour_part.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Year_month_duration/hour_part.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Year_month_duration/negative_years.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Year_month_duration/negative_years.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/annotatedRelationshipElement/idShort/negatively_fuzzed_01.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/annotatedRelationshipElement/idShort/negatively_fuzzed_01.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/annotatedRelationshipElement/idShort/negatively_fuzzed_02.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/annotatedRelationshipElement/idShort/negatively_fuzzed_02.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/annotatedRelationshipElement/idShort/negatively_fuzzed_03.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/annotatedRelationshipElement/idShort/negatively_fuzzed_03.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/annotatedRelationshipElement/idShort/negatively_fuzzed_04.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/annotatedRelationshipElement/idShort/negatively_fuzzed_04.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/annotatedRelationshipElement/idShort/negatively_fuzzed_06.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/annotatedRelationshipElement/idShort/negatively_fuzzed_06.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/annotatedRelationshipElement/idShort/negatively_fuzzed_08.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/annotatedRelationshipElement/idShort/negatively_fuzzed_08.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/annotatedRelationshipElement/idShort/negatively_fuzzed_09.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/annotatedRelationshipElement/idShort/negatively_fuzzed_09.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/annotatedRelationshipElement/idShort/negatively_fuzzed_10.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/annotatedRelationshipElement/idShort/negatively_fuzzed_10.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/assetAdministrationShell/idShort/negatively_fuzzed_01.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/assetAdministrationShell/idShort/negatively_fuzzed_01.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/assetAdministrationShell/idShort/negatively_fuzzed_02.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/assetAdministrationShell/idShort/negatively_fuzzed_02.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/assetAdministrationShell/idShort/negatively_fuzzed_03.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/assetAdministrationShell/idShort/negatively_fuzzed_03.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/assetAdministrationShell/idShort/negatively_fuzzed_04.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/assetAdministrationShell/idShort/negatively_fuzzed_04.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/assetAdministrationShell/idShort/negatively_fuzzed_06.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/assetAdministrationShell/idShort/negatively_fuzzed_06.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/assetAdministrationShell/idShort/negatively_fuzzed_08.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/assetAdministrationShell/idShort/negatively_fuzzed_08.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/assetAdministrationShell/idShort/negatively_fuzzed_09.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/assetAdministrationShell/idShort/negatively_fuzzed_09.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/assetAdministrationShell/idShort/negatively_fuzzed_10.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/assetAdministrationShell/idShort/negatively_fuzzed_10.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/idShort/negatively_fuzzed_01.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/idShort/negatively_fuzzed_01.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/idShort/negatively_fuzzed_02.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/idShort/negatively_fuzzed_02.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/idShort/negatively_fuzzed_03.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/idShort/negatively_fuzzed_03.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/idShort/negatively_fuzzed_04.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/idShort/negatively_fuzzed_04.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/idShort/negatively_fuzzed_06.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/idShort/negatively_fuzzed_06.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/idShort/negatively_fuzzed_08.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/idShort/negatively_fuzzed_08.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/idShort/negatively_fuzzed_09.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/idShort/negatively_fuzzed_09.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/idShort/negatively_fuzzed_10.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/idShort/negatively_fuzzed_10.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/date_time_with_UTC_and_suffix.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/date_time_with_UTC_and_suffix.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].last_update: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].last_update: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/date_time_with_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/date_time_with_offset.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].last_update: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].last_update: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/date_time_without_zone.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/date_time_without_zone.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].last_update: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].last_update: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/empty.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].last_update: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].last_update: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/negatively_fuzzed_02.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/negatively_fuzzed_02.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].last_update: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].last_update: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/negatively_fuzzed_03.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/negatively_fuzzed_03.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].last_update: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].last_update: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/negatively_fuzzed_04.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/negatively_fuzzed_04.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].last_update: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].last_update: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/negatively_fuzzed_05.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/negatively_fuzzed_05.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].last_update: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].last_update: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/negatively_fuzzed_06.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/negatively_fuzzed_06.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].last_update: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].last_update: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/negatively_fuzzed_08.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/negatively_fuzzed_08.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].last_update: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].last_update: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/negatively_fuzzed_09.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/negatively_fuzzed_09.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].last_update: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].last_update: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/negatively_fuzzed_10.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/negatively_fuzzed_10.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].last_update: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].last_update: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/only_date.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/only_date.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].last_update: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].last_update: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/only_date_with_time_zone.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/only_date_with_time_zone.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].last_update: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].last_update: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/without_minutes.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/without_minutes.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].last_update: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].last_update: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/without_seconds.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/lastUpdate/without_seconds.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].last_update: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].last_update: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/date_time_with_UTC_and_suffix.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/date_time_with_UTC_and_suffix.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].max_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].max_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/date_time_with_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/date_time_with_offset.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].max_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].max_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/date_time_without_zone.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/date_time_without_zone.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].max_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].max_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/empty.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].max_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].max_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/negatively_fuzzed_02.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/negatively_fuzzed_02.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].max_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].max_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/negatively_fuzzed_03.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/negatively_fuzzed_03.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].max_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].max_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/negatively_fuzzed_04.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/negatively_fuzzed_04.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].max_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].max_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/negatively_fuzzed_05.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/negatively_fuzzed_05.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].max_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].max_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/negatively_fuzzed_06.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/negatively_fuzzed_06.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].max_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].max_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/negatively_fuzzed_08.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/negatively_fuzzed_08.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].max_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].max_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/negatively_fuzzed_09.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/negatively_fuzzed_09.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].max_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].max_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/negatively_fuzzed_10.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/negatively_fuzzed_10.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].max_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].max_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/only_date.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/only_date.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].max_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].max_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/only_date_with_time_zone.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/only_date_with_time_zone.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].max_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].max_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/without_minutes.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/without_minutes.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].max_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].max_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/without_seconds.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/maxInterval/without_seconds.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].max_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].max_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/date_time_with_UTC_and_suffix.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/date_time_with_UTC_and_suffix.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].min_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].min_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/date_time_with_offset.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/date_time_with_offset.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].min_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].min_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/date_time_without_zone.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/date_time_without_zone.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].min_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].min_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/empty.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].min_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].min_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/negatively_fuzzed_02.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/negatively_fuzzed_02.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].min_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].min_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/negatively_fuzzed_03.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/negatively_fuzzed_03.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].min_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].min_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/negatively_fuzzed_04.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/negatively_fuzzed_04.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].min_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].min_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/negatively_fuzzed_05.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/negatively_fuzzed_05.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].min_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].min_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/negatively_fuzzed_06.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/negatively_fuzzed_06.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].min_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].min_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/negatively_fuzzed_08.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/negatively_fuzzed_08.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].min_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].min_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/negatively_fuzzed_09.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/negatively_fuzzed_09.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].min_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].min_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/negatively_fuzzed_10.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/negatively_fuzzed_10.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].min_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].min_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/only_date.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/only_date.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].min_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].min_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/only_date_with_time_zone.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/only_date_with_time_zone.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].min_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].min_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/without_minutes.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/without_minutes.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].min_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].min_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/without_seconds.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/basicEventElement/minInterval/without_seconds.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].min_interval: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.submodels[0].submodel_elements[0].min_interval: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/blob/contentType/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/blob/contentType/empty.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].content_type: Constraint AASd-100: An attribute with data type ``string`` is not allowed to be empty.
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/blob/contentType/negatively_fuzzed_03.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/blob/contentType/negatively_fuzzed_03.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/blob/contentType/negatively_fuzzed_04.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/blob/contentType/negatively_fuzzed_04.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/blob/contentType/negatively_fuzzed_05.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/blob/contentType/negatively_fuzzed_05.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/blob/contentType/negatively_fuzzed_06.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/blob/contentType/negatively_fuzzed_06.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/blob/contentType/negatively_fuzzed_07.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/blob/contentType/negatively_fuzzed_07.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/blob/contentType/negatively_fuzzed_08.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/blob/contentType/negatively_fuzzed_08.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].content_type: Constraint AASd-100: An attribute with data type ``string`` is not allowed to be empty.
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/blob/contentType/negatively_fuzzed_09.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/blob/contentType/negatively_fuzzed_09.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/blob/contentType/negatively_fuzzed_10.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/blob/contentType/negatively_fuzzed_10.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/blob/contentType/number.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/blob/contentType/number.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/blob/idShort/negatively_fuzzed_01.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/blob/idShort/negatively_fuzzed_01.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/blob/idShort/negatively_fuzzed_02.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/blob/idShort/negatively_fuzzed_02.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/blob/idShort/negatively_fuzzed_03.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/blob/idShort/negatively_fuzzed_03.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/blob/idShort/negatively_fuzzed_04.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/blob/idShort/negatively_fuzzed_04.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/blob/idShort/negatively_fuzzed_06.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/blob/idShort/negatively_fuzzed_06.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/blob/idShort/negatively_fuzzed_08.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/blob/idShort/negatively_fuzzed_08.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/blob/idShort/negatively_fuzzed_09.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/blob/idShort/negatively_fuzzed_09.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/blob/idShort/negatively_fuzzed_10.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/blob/idShort/negatively_fuzzed_10.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/capability/idShort/negatively_fuzzed_01.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/capability/idShort/negatively_fuzzed_01.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/capability/idShort/negatively_fuzzed_02.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/capability/idShort/negatively_fuzzed_02.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/capability/idShort/negatively_fuzzed_03.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/capability/idShort/negatively_fuzzed_03.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/capability/idShort/negatively_fuzzed_04.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/capability/idShort/negatively_fuzzed_04.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/capability/idShort/negatively_fuzzed_06.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/capability/idShort/negatively_fuzzed_06.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/capability/idShort/negatively_fuzzed_08.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/capability/idShort/negatively_fuzzed_08.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/capability/idShort/negatively_fuzzed_09.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/capability/idShort/negatively_fuzzed_09.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/capability/idShort/negatively_fuzzed_10.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/capability/idShort/negatively_fuzzed_10.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/conceptDescription/idShort/negatively_fuzzed_01.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/conceptDescription/idShort/negatively_fuzzed_01.xml.errors
@@ -1,0 +1,1 @@
+.concept_descriptions[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/conceptDescription/idShort/negatively_fuzzed_02.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/conceptDescription/idShort/negatively_fuzzed_02.xml.errors
@@ -1,0 +1,1 @@
+.concept_descriptions[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/conceptDescription/idShort/negatively_fuzzed_03.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/conceptDescription/idShort/negatively_fuzzed_03.xml.errors
@@ -1,0 +1,1 @@
+.concept_descriptions[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/conceptDescription/idShort/negatively_fuzzed_04.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/conceptDescription/idShort/negatively_fuzzed_04.xml.errors
@@ -1,0 +1,1 @@
+.concept_descriptions[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/conceptDescription/idShort/negatively_fuzzed_06.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/conceptDescription/idShort/negatively_fuzzed_06.xml.errors
@@ -1,0 +1,1 @@
+.concept_descriptions[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/conceptDescription/idShort/negatively_fuzzed_08.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/conceptDescription/idShort/negatively_fuzzed_08.xml.errors
@@ -1,0 +1,1 @@
+.concept_descriptions[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/conceptDescription/idShort/negatively_fuzzed_09.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/conceptDescription/idShort/negatively_fuzzed_09.xml.errors
@@ -1,0 +1,1 @@
+.concept_descriptions[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/conceptDescription/idShort/negatively_fuzzed_10.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/conceptDescription/idShort/negatively_fuzzed_10.xml.errors
@@ -1,0 +1,1 @@
+.concept_descriptions[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/entity/idShort/negatively_fuzzed_01.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/entity/idShort/negatively_fuzzed_01.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/entity/idShort/negatively_fuzzed_02.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/entity/idShort/negatively_fuzzed_02.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/entity/idShort/negatively_fuzzed_03.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/entity/idShort/negatively_fuzzed_03.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/entity/idShort/negatively_fuzzed_04.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/entity/idShort/negatively_fuzzed_04.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/entity/idShort/negatively_fuzzed_06.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/entity/idShort/negatively_fuzzed_06.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/entity/idShort/negatively_fuzzed_08.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/entity/idShort/negatively_fuzzed_08.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/entity/idShort/negatively_fuzzed_09.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/entity/idShort/negatively_fuzzed_09.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/entity/idShort/negatively_fuzzed_10.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/entity/idShort/negatively_fuzzed_10.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/contentType/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/contentType/empty.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].content_type: Constraint AASd-100: An attribute with data type ``string`` is not allowed to be empty.
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/contentType/negatively_fuzzed_03.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/contentType/negatively_fuzzed_03.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/contentType/negatively_fuzzed_04.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/contentType/negatively_fuzzed_04.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/contentType/negatively_fuzzed_05.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/contentType/negatively_fuzzed_05.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/contentType/negatively_fuzzed_06.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/contentType/negatively_fuzzed_06.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/contentType/negatively_fuzzed_07.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/contentType/negatively_fuzzed_07.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/contentType/negatively_fuzzed_08.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/contentType/negatively_fuzzed_08.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].content_type: Constraint AASd-100: An attribute with data type ``string`` is not allowed to be empty.
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/contentType/negatively_fuzzed_09.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/contentType/negatively_fuzzed_09.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/contentType/negatively_fuzzed_10.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/contentType/negatively_fuzzed_10.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/contentType/number.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/contentType/number.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/idShort/negatively_fuzzed_01.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/idShort/negatively_fuzzed_01.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/idShort/negatively_fuzzed_02.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/idShort/negatively_fuzzed_02.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/idShort/negatively_fuzzed_03.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/idShort/negatively_fuzzed_03.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/idShort/negatively_fuzzed_04.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/idShort/negatively_fuzzed_04.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/idShort/negatively_fuzzed_06.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/idShort/negatively_fuzzed_06.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/idShort/negatively_fuzzed_08.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/idShort/negatively_fuzzed_08.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/idShort/negatively_fuzzed_09.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/idShort/negatively_fuzzed_09.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/idShort/negatively_fuzzed_10.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/idShort/negatively_fuzzed_10.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/value/absolute_path_without_scheme.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/value/absolute_path_without_scheme.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].value: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/value/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/value/empty.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0].value: Constraint AASd-100: An attribute with data type ``string`` is not allowed to be empty.
+.submodels[0].submodel_elements[0].value: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/value/local_relative_path_with_scheme.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/value/local_relative_path_with_scheme.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].value: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/value/negatively_fuzzed_01.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/value/negatively_fuzzed_01.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].value: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/value/negatively_fuzzed_02.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/value/negatively_fuzzed_02.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].value: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/value/negatively_fuzzed_03.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/value/negatively_fuzzed_03.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].value: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/value/negatively_fuzzed_04.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/value/negatively_fuzzed_04.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].value: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/value/negatively_fuzzed_06.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/value/negatively_fuzzed_06.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].value: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/value/negatively_fuzzed_07.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/value/negatively_fuzzed_07.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].value: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/value/negatively_fuzzed_08.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/value/negatively_fuzzed_08.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].value: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/value/negatively_fuzzed_09.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/value/negatively_fuzzed_09.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].value: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/value/negatively_fuzzed_10.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/value/negatively_fuzzed_10.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].value: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/value/number.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/value/number.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].value: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/value/relative_path_without_scheme.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/file/value/relative_path_without_scheme.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].value: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/langString/language/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/langString/language/empty.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].display_name[0].language: The value must represent a value language tag conformant to BCP 47.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/langString/language/free_form_text.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/langString/language/free_form_text.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].display_name[0].language: The value must represent a value language tag conformant to BCP 47.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/langString/language/negatively_fuzzed_02.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/langString/language/negatively_fuzzed_02.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].display_name[0].language: The value must represent a value language tag conformant to BCP 47.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/langString/language/negatively_fuzzed_03.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/langString/language/negatively_fuzzed_03.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].display_name[0].language: The value must represent a value language tag conformant to BCP 47.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/langString/language/negatively_fuzzed_04.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/langString/language/negatively_fuzzed_04.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].display_name[0].language: The value must represent a value language tag conformant to BCP 47.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/langString/language/negatively_fuzzed_05.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/langString/language/negatively_fuzzed_05.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].display_name[0].language: The value must represent a value language tag conformant to BCP 47.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/langString/language/negatively_fuzzed_06.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/langString/language/negatively_fuzzed_06.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].display_name[0].language: The value must represent a value language tag conformant to BCP 47.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/langString/language/negatively_fuzzed_07.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/langString/language/negatively_fuzzed_07.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].display_name[0].language: The value must represent a value language tag conformant to BCP 47.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/langString/language/negatively_fuzzed_08.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/langString/language/negatively_fuzzed_08.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].display_name[0].language: The value must represent a value language tag conformant to BCP 47.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/langString/language/negatively_fuzzed_09.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/langString/language/negatively_fuzzed_09.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].display_name[0].language: The value must represent a value language tag conformant to BCP 47.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/multiLanguageProperty/idShort/negatively_fuzzed_01.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/multiLanguageProperty/idShort/negatively_fuzzed_01.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/multiLanguageProperty/idShort/negatively_fuzzed_02.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/multiLanguageProperty/idShort/negatively_fuzzed_02.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/multiLanguageProperty/idShort/negatively_fuzzed_03.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/multiLanguageProperty/idShort/negatively_fuzzed_03.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/multiLanguageProperty/idShort/negatively_fuzzed_04.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/multiLanguageProperty/idShort/negatively_fuzzed_04.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/multiLanguageProperty/idShort/negatively_fuzzed_06.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/multiLanguageProperty/idShort/negatively_fuzzed_06.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/multiLanguageProperty/idShort/negatively_fuzzed_08.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/multiLanguageProperty/idShort/negatively_fuzzed_08.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/multiLanguageProperty/idShort/negatively_fuzzed_09.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/multiLanguageProperty/idShort/negatively_fuzzed_09.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/multiLanguageProperty/idShort/negatively_fuzzed_10.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/multiLanguageProperty/idShort/negatively_fuzzed_10.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/operation/idShort/negatively_fuzzed_01.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/operation/idShort/negatively_fuzzed_01.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/operation/idShort/negatively_fuzzed_02.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/operation/idShort/negatively_fuzzed_02.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/operation/idShort/negatively_fuzzed_03.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/operation/idShort/negatively_fuzzed_03.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/operation/idShort/negatively_fuzzed_04.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/operation/idShort/negatively_fuzzed_04.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/operation/idShort/negatively_fuzzed_06.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/operation/idShort/negatively_fuzzed_06.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/operation/idShort/negatively_fuzzed_08.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/operation/idShort/negatively_fuzzed_08.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/operation/idShort/negatively_fuzzed_09.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/operation/idShort/negatively_fuzzed_09.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/operation/idShort/negatively_fuzzed_10.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/operation/idShort/negatively_fuzzed_10.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/property/idShort/negatively_fuzzed_01.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/property/idShort/negatively_fuzzed_01.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/property/idShort/negatively_fuzzed_02.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/property/idShort/negatively_fuzzed_02.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/property/idShort/negatively_fuzzed_03.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/property/idShort/negatively_fuzzed_03.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/property/idShort/negatively_fuzzed_04.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/property/idShort/negatively_fuzzed_04.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/property/idShort/negatively_fuzzed_06.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/property/idShort/negatively_fuzzed_06.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/property/idShort/negatively_fuzzed_08.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/property/idShort/negatively_fuzzed_08.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/property/idShort/negatively_fuzzed_09.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/property/idShort/negatively_fuzzed_09.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/property/idShort/negatively_fuzzed_10.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/property/idShort/negatively_fuzzed_10.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/range/idShort/negatively_fuzzed_01.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/range/idShort/negatively_fuzzed_01.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/range/idShort/negatively_fuzzed_02.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/range/idShort/negatively_fuzzed_02.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/range/idShort/negatively_fuzzed_03.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/range/idShort/negatively_fuzzed_03.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/range/idShort/negatively_fuzzed_04.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/range/idShort/negatively_fuzzed_04.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/range/idShort/negatively_fuzzed_06.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/range/idShort/negatively_fuzzed_06.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/range/idShort/negatively_fuzzed_08.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/range/idShort/negatively_fuzzed_08.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/range/idShort/negatively_fuzzed_09.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/range/idShort/negatively_fuzzed_09.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/range/idShort/negatively_fuzzed_10.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/range/idShort/negatively_fuzzed_10.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/referenceElement/idShort/negatively_fuzzed_01.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/referenceElement/idShort/negatively_fuzzed_01.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/referenceElement/idShort/negatively_fuzzed_02.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/referenceElement/idShort/negatively_fuzzed_02.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/referenceElement/idShort/negatively_fuzzed_03.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/referenceElement/idShort/negatively_fuzzed_03.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/referenceElement/idShort/negatively_fuzzed_04.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/referenceElement/idShort/negatively_fuzzed_04.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/referenceElement/idShort/negatively_fuzzed_06.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/referenceElement/idShort/negatively_fuzzed_06.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/referenceElement/idShort/negatively_fuzzed_08.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/referenceElement/idShort/negatively_fuzzed_08.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/referenceElement/idShort/negatively_fuzzed_09.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/referenceElement/idShort/negatively_fuzzed_09.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/referenceElement/idShort/negatively_fuzzed_10.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/referenceElement/idShort/negatively_fuzzed_10.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/relationshipElement/idShort/negatively_fuzzed_01.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/relationshipElement/idShort/negatively_fuzzed_01.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/relationshipElement/idShort/negatively_fuzzed_02.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/relationshipElement/idShort/negatively_fuzzed_02.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/relationshipElement/idShort/negatively_fuzzed_03.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/relationshipElement/idShort/negatively_fuzzed_03.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/relationshipElement/idShort/negatively_fuzzed_04.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/relationshipElement/idShort/negatively_fuzzed_04.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/relationshipElement/idShort/negatively_fuzzed_06.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/relationshipElement/idShort/negatively_fuzzed_06.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/relationshipElement/idShort/negatively_fuzzed_08.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/relationshipElement/idShort/negatively_fuzzed_08.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/relationshipElement/idShort/negatively_fuzzed_09.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/relationshipElement/idShort/negatively_fuzzed_09.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/relationshipElement/idShort/negatively_fuzzed_10.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/relationshipElement/idShort/negatively_fuzzed_10.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/contentType/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/contentType/empty.xml.errors
@@ -1,0 +1,2 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.content_type: Constraint AASd-100: An attribute with data type ``string`` is not allowed to be empty.
+.asset_administration_shells[0].asset_information.default_thumbnail.content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/contentType/negatively_fuzzed_03.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/contentType/negatively_fuzzed_03.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/contentType/negatively_fuzzed_04.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/contentType/negatively_fuzzed_04.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/contentType/negatively_fuzzed_05.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/contentType/negatively_fuzzed_05.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/contentType/negatively_fuzzed_06.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/contentType/negatively_fuzzed_06.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/contentType/negatively_fuzzed_07.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/contentType/negatively_fuzzed_07.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/contentType/negatively_fuzzed_08.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/contentType/negatively_fuzzed_08.xml.errors
@@ -1,0 +1,2 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.content_type: Constraint AASd-100: An attribute with data type ``string`` is not allowed to be empty.
+.asset_administration_shells[0].asset_information.default_thumbnail.content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/contentType/negatively_fuzzed_09.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/contentType/negatively_fuzzed_09.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/contentType/negatively_fuzzed_10.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/contentType/negatively_fuzzed_10.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/contentType/number.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/contentType/number.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.content_type: The value must represent a valid content MIME type according to RFC 2046.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/path/absolute_path_without_scheme.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/path/absolute_path_without_scheme.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.path: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/path/empty.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/path/empty.xml.errors
@@ -1,0 +1,2 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.path: Constraint AASd-100: An attribute with data type ``string`` is not allowed to be empty.
+.asset_administration_shells[0].asset_information.default_thumbnail.path: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/path/local_relative_path_with_scheme.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/path/local_relative_path_with_scheme.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.path: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/path/negatively_fuzzed_01.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/path/negatively_fuzzed_01.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.path: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/path/negatively_fuzzed_02.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/path/negatively_fuzzed_02.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.path: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/path/negatively_fuzzed_03.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/path/negatively_fuzzed_03.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.path: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/path/negatively_fuzzed_04.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/path/negatively_fuzzed_04.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.path: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/path/negatively_fuzzed_06.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/path/negatively_fuzzed_06.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.path: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/path/negatively_fuzzed_07.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/path/negatively_fuzzed_07.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.path: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/path/negatively_fuzzed_08.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/path/negatively_fuzzed_08.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.path: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/path/negatively_fuzzed_09.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/path/negatively_fuzzed_09.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.path: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/path/negatively_fuzzed_10.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/path/negatively_fuzzed_10.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.path: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/path/number.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/path/number.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.path: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/path/relative_path_without_scheme.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/resource/path/relative_path_without_scheme.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].asset_information.default_thumbnail.path: The value must represent a valid file URI scheme according to RFC 8089.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodel/idShort/negatively_fuzzed_01.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodel/idShort/negatively_fuzzed_01.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodel/idShort/negatively_fuzzed_02.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodel/idShort/negatively_fuzzed_02.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodel/idShort/negatively_fuzzed_03.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodel/idShort/negatively_fuzzed_03.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodel/idShort/negatively_fuzzed_04.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodel/idShort/negatively_fuzzed_04.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodel/idShort/negatively_fuzzed_06.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodel/idShort/negatively_fuzzed_06.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodel/idShort/negatively_fuzzed_08.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodel/idShort/negatively_fuzzed_08.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodel/idShort/negatively_fuzzed_09.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodel/idShort/negatively_fuzzed_09.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodel/idShort/negatively_fuzzed_10.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodel/idShort/negatively_fuzzed_10.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodelElementCollection/idShort/negatively_fuzzed_01.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodelElementCollection/idShort/negatively_fuzzed_01.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodelElementCollection/idShort/negatively_fuzzed_02.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodelElementCollection/idShort/negatively_fuzzed_02.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodelElementCollection/idShort/negatively_fuzzed_03.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodelElementCollection/idShort/negatively_fuzzed_03.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodelElementCollection/idShort/negatively_fuzzed_04.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodelElementCollection/idShort/negatively_fuzzed_04.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodelElementCollection/idShort/negatively_fuzzed_06.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodelElementCollection/idShort/negatively_fuzzed_06.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodelElementCollection/idShort/negatively_fuzzed_08.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodelElementCollection/idShort/negatively_fuzzed_08.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodelElementCollection/idShort/negatively_fuzzed_09.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodelElementCollection/idShort/negatively_fuzzed_09.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodelElementCollection/idShort/negatively_fuzzed_10.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodelElementCollection/idShort/negatively_fuzzed_10.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodelElementList/idShort/negatively_fuzzed_01.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodelElementList/idShort/negatively_fuzzed_01.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodelElementList/idShort/negatively_fuzzed_02.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodelElementList/idShort/negatively_fuzzed_02.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodelElementList/idShort/negatively_fuzzed_03.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodelElementList/idShort/negatively_fuzzed_03.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodelElementList/idShort/negatively_fuzzed_04.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodelElementList/idShort/negatively_fuzzed_04.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodelElementList/idShort/negatively_fuzzed_06.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodelElementList/idShort/negatively_fuzzed_06.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodelElementList/idShort/negatively_fuzzed_08.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodelElementList/idShort/negatively_fuzzed_08.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodelElementList/idShort/negatively_fuzzed_09.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodelElementList/idShort/negatively_fuzzed_09.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodelElementList/idShort/negatively_fuzzed_10.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/PatternViolation/submodelElementList/idShort/negatively_fuzzed_10.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0].id_short: ID-short of Referables shall only feature letters, digits, underscore (``_``); starting mandatory with a letter. *I.e.* ``[a-zA-Z][a-zA-Z0-9_]+``.

--- a/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/date_time_with_UTC_and_suffix.xml.errors
+++ b/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/date_time_with_UTC_and_suffix.xml.errors
@@ -1,0 +1,2 @@
+.time_stamp: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.time_stamp: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/date_time_with_offset.xml.errors
+++ b/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/date_time_with_offset.xml.errors
@@ -1,0 +1,2 @@
+.time_stamp: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.time_stamp: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/date_time_without_zone.xml.errors
+++ b/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/date_time_without_zone.xml.errors
@@ -1,0 +1,2 @@
+.time_stamp: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.time_stamp: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/empty.xml.errors
+++ b/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/empty.xml.errors
@@ -1,0 +1,2 @@
+.time_stamp: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.time_stamp: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/negatively_fuzzed_02.xml.errors
+++ b/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/negatively_fuzzed_02.xml.errors
@@ -1,0 +1,2 @@
+.time_stamp: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.time_stamp: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/negatively_fuzzed_03.xml.errors
+++ b/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/negatively_fuzzed_03.xml.errors
@@ -1,0 +1,2 @@
+.time_stamp: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.time_stamp: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/negatively_fuzzed_04.xml.errors
+++ b/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/negatively_fuzzed_04.xml.errors
@@ -1,0 +1,2 @@
+.time_stamp: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.time_stamp: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/negatively_fuzzed_05.xml.errors
+++ b/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/negatively_fuzzed_05.xml.errors
@@ -1,0 +1,2 @@
+.time_stamp: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.time_stamp: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/negatively_fuzzed_06.xml.errors
+++ b/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/negatively_fuzzed_06.xml.errors
@@ -1,0 +1,2 @@
+.time_stamp: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.time_stamp: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/negatively_fuzzed_08.xml.errors
+++ b/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/negatively_fuzzed_08.xml.errors
@@ -1,0 +1,2 @@
+.time_stamp: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.time_stamp: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/negatively_fuzzed_09.xml.errors
+++ b/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/negatively_fuzzed_09.xml.errors
@@ -1,0 +1,2 @@
+.time_stamp: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.time_stamp: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/negatively_fuzzed_10.xml.errors
+++ b/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/negatively_fuzzed_10.xml.errors
@@ -1,0 +1,2 @@
+.time_stamp: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.time_stamp: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/only_date.xml.errors
+++ b/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/only_date.xml.errors
@@ -1,0 +1,2 @@
+.time_stamp: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.time_stamp: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/only_date_with_time_zone.xml.errors
+++ b/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/only_date_with_time_zone.xml.errors
@@ -1,0 +1,2 @@
+.time_stamp: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.time_stamp: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/without_minutes.xml.errors
+++ b/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/without_minutes.xml.errors
@@ -1,0 +1,2 @@
+.time_stamp: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.time_stamp: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/without_seconds.xml.errors
+++ b/test_data/Xml/SelfContained/Unexpected/PatternViolation/eventPayload/timeStamp/without_seconds.xml.errors
@@ -1,0 +1,2 @@
+.time_stamp: The value must match the pattern of xs:dateTimeStamp with the time zone fixed to UTC.
+.time_stamp: The value must represent a valid xs:dateTimeStamp with the time zone fixed to UTC.

--- a/tests/test_jsonization_of_concrete_classes.py
+++ b/tests/test_jsonization_of_concrete_classes.py
@@ -45,7 +45,7 @@ class Test_Extension(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "Extension"
-            ).glob("*.json")
+            ).glob("**/*.json")
         )
 
         for path in paths:
@@ -106,7 +106,7 @@ class Test_Extension(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -145,7 +145,7 @@ class Test_Extension(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -184,7 +184,7 @@ class Test_AdministrativeInformation(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "AdministrativeInformation"
-            ).glob("*.json")
+            ).glob("**/*.json")
         )
 
         for path in paths:
@@ -245,7 +245,7 @@ class Test_AdministrativeInformation(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -284,7 +284,7 @@ class Test_AdministrativeInformation(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -323,7 +323,7 @@ class Test_Qualifier(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "Qualifier"
-            ).glob("*.json")
+            ).glob("**/*.json")
         )
 
         for path in paths:
@@ -384,7 +384,7 @@ class Test_Qualifier(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -423,7 +423,7 @@ class Test_Qualifier(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -462,7 +462,7 @@ class Test_AssetAdministrationShell(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "AssetAdministrationShell"
-            ).glob("*.json")
+            ).glob("**/*.json")
         )
 
         for path in paths:
@@ -523,7 +523,7 @@ class Test_AssetAdministrationShell(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -562,7 +562,7 @@ class Test_AssetAdministrationShell(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -601,7 +601,7 @@ class Test_AssetInformation(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "AssetInformation"
-            ).glob("*.json")
+            ).glob("**/*.json")
         )
 
         for path in paths:
@@ -662,7 +662,7 @@ class Test_AssetInformation(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -701,7 +701,7 @@ class Test_AssetInformation(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -740,7 +740,7 @@ class Test_Resource(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "Resource"
-            ).glob("*.json")
+            ).glob("**/*.json")
         )
 
         for path in paths:
@@ -801,7 +801,7 @@ class Test_Resource(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -840,7 +840,7 @@ class Test_Resource(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -879,7 +879,7 @@ class Test_SpecificAssetId(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "SpecificAssetId"
-            ).glob("*.json")
+            ).glob("**/*.json")
         )
 
         for path in paths:
@@ -940,7 +940,7 @@ class Test_SpecificAssetId(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -979,7 +979,7 @@ class Test_SpecificAssetId(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -1018,7 +1018,7 @@ class Test_Submodel(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "Submodel"
-            ).glob("*.json")
+            ).glob("**/*.json")
         )
 
         for path in paths:
@@ -1079,7 +1079,7 @@ class Test_Submodel(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -1118,7 +1118,7 @@ class Test_Submodel(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -1157,7 +1157,7 @@ class Test_RelationshipElement(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "RelationshipElement"
-            ).glob("*.json")
+            ).glob("**/*.json")
         )
 
         for path in paths:
@@ -1218,7 +1218,7 @@ class Test_RelationshipElement(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -1257,7 +1257,7 @@ class Test_RelationshipElement(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -1296,7 +1296,7 @@ class Test_SubmodelElementList(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "SubmodelElementList"
-            ).glob("*.json")
+            ).glob("**/*.json")
         )
 
         for path in paths:
@@ -1357,7 +1357,7 @@ class Test_SubmodelElementList(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -1396,7 +1396,7 @@ class Test_SubmodelElementList(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -1435,7 +1435,7 @@ class Test_SubmodelElementCollection(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "SubmodelElementCollection"
-            ).glob("*.json")
+            ).glob("**/*.json")
         )
 
         for path in paths:
@@ -1496,7 +1496,7 @@ class Test_SubmodelElementCollection(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -1535,7 +1535,7 @@ class Test_SubmodelElementCollection(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -1574,7 +1574,7 @@ class Test_Property(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "Property"
-            ).glob("*.json")
+            ).glob("**/*.json")
         )
 
         for path in paths:
@@ -1635,7 +1635,7 @@ class Test_Property(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -1674,7 +1674,7 @@ class Test_Property(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -1713,7 +1713,7 @@ class Test_MultiLanguageProperty(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "MultiLanguageProperty"
-            ).glob("*.json")
+            ).glob("**/*.json")
         )
 
         for path in paths:
@@ -1774,7 +1774,7 @@ class Test_MultiLanguageProperty(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -1813,7 +1813,7 @@ class Test_MultiLanguageProperty(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -1852,7 +1852,7 @@ class Test_Range(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "Range"
-            ).glob("*.json")
+            ).glob("**/*.json")
         )
 
         for path in paths:
@@ -1913,7 +1913,7 @@ class Test_Range(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -1952,7 +1952,7 @@ class Test_Range(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -1991,7 +1991,7 @@ class Test_ReferenceElement(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "ReferenceElement"
-            ).glob("*.json")
+            ).glob("**/*.json")
         )
 
         for path in paths:
@@ -2052,7 +2052,7 @@ class Test_ReferenceElement(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -2091,7 +2091,7 @@ class Test_ReferenceElement(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -2130,7 +2130,7 @@ class Test_Blob(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "Blob"
-            ).glob("*.json")
+            ).glob("**/*.json")
         )
 
         for path in paths:
@@ -2191,7 +2191,7 @@ class Test_Blob(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -2230,7 +2230,7 @@ class Test_Blob(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -2269,7 +2269,7 @@ class Test_File(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "File"
-            ).glob("*.json")
+            ).glob("**/*.json")
         )
 
         for path in paths:
@@ -2330,7 +2330,7 @@ class Test_File(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -2369,7 +2369,7 @@ class Test_File(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -2408,7 +2408,7 @@ class Test_AnnotatedRelationshipElement(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "AnnotatedRelationshipElement"
-            ).glob("*.json")
+            ).glob("**/*.json")
         )
 
         for path in paths:
@@ -2469,7 +2469,7 @@ class Test_AnnotatedRelationshipElement(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -2508,7 +2508,7 @@ class Test_AnnotatedRelationshipElement(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -2547,7 +2547,7 @@ class Test_Entity(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "Entity"
-            ).glob("*.json")
+            ).glob("**/*.json")
         )
 
         for path in paths:
@@ -2608,7 +2608,7 @@ class Test_Entity(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -2647,7 +2647,7 @@ class Test_Entity(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -2686,7 +2686,7 @@ class Test_EventPayload(unittest.TestCase):
                 / "SelfContained"
                 / "Expected"
                 / "EventPayload"
-            ).glob("*.json")
+            ).glob("**/*.json")
         )
 
         for path in paths:
@@ -2747,7 +2747,7 @@ class Test_EventPayload(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -2786,7 +2786,7 @@ class Test_EventPayload(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -2825,7 +2825,7 @@ class Test_BasicEventElement(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "BasicEventElement"
-            ).glob("*.json")
+            ).glob("**/*.json")
         )
 
         for path in paths:
@@ -2886,7 +2886,7 @@ class Test_BasicEventElement(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -2925,7 +2925,7 @@ class Test_BasicEventElement(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -2964,7 +2964,7 @@ class Test_Operation(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "Operation"
-            ).glob("*.json")
+            ).glob("**/*.json")
         )
 
         for path in paths:
@@ -3025,7 +3025,7 @@ class Test_Operation(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -3064,7 +3064,7 @@ class Test_Operation(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -3103,7 +3103,7 @@ class Test_OperationVariable(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "OperationVariable"
-            ).glob("*.json")
+            ).glob("**/*.json")
         )
 
         for path in paths:
@@ -3164,7 +3164,7 @@ class Test_OperationVariable(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -3203,7 +3203,7 @@ class Test_OperationVariable(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -3242,7 +3242,7 @@ class Test_Capability(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "Capability"
-            ).glob("*.json")
+            ).glob("**/*.json")
         )
 
         for path in paths:
@@ -3303,7 +3303,7 @@ class Test_Capability(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -3342,7 +3342,7 @@ class Test_Capability(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -3381,7 +3381,7 @@ class Test_ConceptDescription(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "ConceptDescription"
-            ).glob("*.json")
+            ).glob("**/*.json")
         )
 
         for path in paths:
@@ -3442,7 +3442,7 @@ class Test_ConceptDescription(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -3481,7 +3481,7 @@ class Test_ConceptDescription(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -3520,7 +3520,7 @@ class Test_Reference(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "Reference"
-            ).glob("*.json")
+            ).glob("**/*.json")
         )
 
         for path in paths:
@@ -3581,7 +3581,7 @@ class Test_Reference(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -3620,7 +3620,7 @@ class Test_Reference(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -3659,7 +3659,7 @@ class Test_Key(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "Key"
-            ).glob("*.json")
+            ).glob("**/*.json")
         )
 
         for path in paths:
@@ -3720,7 +3720,7 @@ class Test_Key(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -3759,7 +3759,7 @@ class Test_Key(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -3798,7 +3798,7 @@ class Test_LangString(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "LangString"
-            ).glob("*.json")
+            ).glob("**/*.json")
         )
 
         for path in paths:
@@ -3859,7 +3859,7 @@ class Test_LangString(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -3898,7 +3898,7 @@ class Test_LangString(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -3937,7 +3937,7 @@ class Test_Environment(unittest.TestCase):
                 / "SelfContained"
                 / "Expected"
                 / "Environment"
-            ).glob("*.json")
+            ).glob("**/*.json")
         )
 
         for path in paths:
@@ -3998,7 +3998,7 @@ class Test_Environment(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -4037,7 +4037,7 @@ class Test_Environment(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -4076,7 +4076,7 @@ class Test_EmbeddedDataSpecification(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "EmbeddedDataSpecification"
-            ).glob("*.json")
+            ).glob("**/*.json")
         )
 
         for path in paths:
@@ -4137,7 +4137,7 @@ class Test_EmbeddedDataSpecification(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -4176,7 +4176,7 @@ class Test_EmbeddedDataSpecification(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -4215,7 +4215,7 @@ class Test_ValueReferencePair(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "ValueReferencePair"
-            ).glob("*.json")
+            ).glob("**/*.json")
         )
 
         for path in paths:
@@ -4276,7 +4276,7 @@ class Test_ValueReferencePair(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -4315,7 +4315,7 @@ class Test_ValueReferencePair(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -4354,7 +4354,7 @@ class Test_ValueList(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "ValueList"
-            ).glob("*.json")
+            ).glob("**/*.json")
         )
 
         for path in paths:
@@ -4415,7 +4415,7 @@ class Test_ValueList(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -4454,7 +4454,7 @@ class Test_ValueList(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -4493,7 +4493,7 @@ class Test_DataSpecificationIEC61360(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "DataSpecificationIEC61360"
-            ).glob("*.json")
+            ).glob("**/*.json")
         )
 
         for path in paths:
@@ -4554,7 +4554,7 @@ class Test_DataSpecificationIEC61360(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -4593,7 +4593,7 @@ class Test_DataSpecificationIEC61360(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -4632,7 +4632,7 @@ class Test_DataSpecificationPhysicalUnit(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "DataSpecificationPhysicalUnit"
-            ).glob("*.json")
+            ).glob("**/*.json")
         )
 
         for path in paths:
@@ -4693,7 +4693,7 @@ class Test_DataSpecificationPhysicalUnit(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 
@@ -4732,7 +4732,7 @@ class Test_DataSpecificationPhysicalUnit(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.json")):
+            for path in sorted(base_dir.glob("**/*.json")):
                 with path.open("rt") as fid:
                     jsonable = json.load(fid)
 

--- a/tests/test_xmlization_of_concrete_classes.py
+++ b/tests/test_xmlization_of_concrete_classes.py
@@ -43,7 +43,7 @@ class Test_Extension(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "extension"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -91,7 +91,7 @@ class Test_Extension(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 observed_exception: Optional[
                     aas_xmlization.DeserializationException
                 ] = None
@@ -129,7 +129,7 @@ class Test_Extension(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 try:
                     container = aas_xmlization.environment_from_str(
                         path.read_text(encoding="utf-8")
@@ -161,7 +161,7 @@ class Test_Extension(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "extension"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -217,7 +217,7 @@ class Test_AdministrativeInformation(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "administrativeInformation"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -265,7 +265,7 @@ class Test_AdministrativeInformation(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 observed_exception: Optional[
                     aas_xmlization.DeserializationException
                 ] = None
@@ -303,7 +303,7 @@ class Test_AdministrativeInformation(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 try:
                     container = aas_xmlization.environment_from_str(
                         path.read_text(encoding="utf-8")
@@ -335,7 +335,7 @@ class Test_AdministrativeInformation(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "administrativeInformation"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -391,7 +391,7 @@ class Test_Qualifier(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "qualifier"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -439,7 +439,7 @@ class Test_Qualifier(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 observed_exception: Optional[
                     aas_xmlization.DeserializationException
                 ] = None
@@ -477,7 +477,7 @@ class Test_Qualifier(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 try:
                     container = aas_xmlization.environment_from_str(
                         path.read_text(encoding="utf-8")
@@ -509,7 +509,7 @@ class Test_Qualifier(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "qualifier"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -565,7 +565,7 @@ class Test_AssetAdministrationShell(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "assetAdministrationShell"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -613,7 +613,7 @@ class Test_AssetAdministrationShell(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 observed_exception: Optional[
                     aas_xmlization.DeserializationException
                 ] = None
@@ -651,7 +651,7 @@ class Test_AssetAdministrationShell(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 try:
                     container = aas_xmlization.environment_from_str(
                         path.read_text(encoding="utf-8")
@@ -683,7 +683,7 @@ class Test_AssetAdministrationShell(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "assetAdministrationShell"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -739,7 +739,7 @@ class Test_AssetInformation(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "assetInformation"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -787,7 +787,7 @@ class Test_AssetInformation(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 observed_exception: Optional[
                     aas_xmlization.DeserializationException
                 ] = None
@@ -825,7 +825,7 @@ class Test_AssetInformation(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 try:
                     container = aas_xmlization.environment_from_str(
                         path.read_text(encoding="utf-8")
@@ -857,7 +857,7 @@ class Test_AssetInformation(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "assetInformation"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -913,7 +913,7 @@ class Test_Resource(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "resource"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -961,7 +961,7 @@ class Test_Resource(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 observed_exception: Optional[
                     aas_xmlization.DeserializationException
                 ] = None
@@ -999,7 +999,7 @@ class Test_Resource(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 try:
                     container = aas_xmlization.environment_from_str(
                         path.read_text(encoding="utf-8")
@@ -1031,7 +1031,7 @@ class Test_Resource(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "resource"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -1087,7 +1087,7 @@ class Test_SpecificAssetId(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "specificAssetId"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -1135,7 +1135,7 @@ class Test_SpecificAssetId(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 observed_exception: Optional[
                     aas_xmlization.DeserializationException
                 ] = None
@@ -1173,7 +1173,7 @@ class Test_SpecificAssetId(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 try:
                     container = aas_xmlization.environment_from_str(
                         path.read_text(encoding="utf-8")
@@ -1205,7 +1205,7 @@ class Test_SpecificAssetId(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "specificAssetId"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -1261,7 +1261,7 @@ class Test_Submodel(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "submodel"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -1309,7 +1309,7 @@ class Test_Submodel(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 observed_exception: Optional[
                     aas_xmlization.DeserializationException
                 ] = None
@@ -1347,7 +1347,7 @@ class Test_Submodel(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 try:
                     container = aas_xmlization.environment_from_str(
                         path.read_text(encoding="utf-8")
@@ -1379,7 +1379,7 @@ class Test_Submodel(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "submodel"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -1435,7 +1435,7 @@ class Test_RelationshipElement(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "relationshipElement"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -1483,7 +1483,7 @@ class Test_RelationshipElement(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 observed_exception: Optional[
                     aas_xmlization.DeserializationException
                 ] = None
@@ -1521,7 +1521,7 @@ class Test_RelationshipElement(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 try:
                     container = aas_xmlization.environment_from_str(
                         path.read_text(encoding="utf-8")
@@ -1553,7 +1553,7 @@ class Test_RelationshipElement(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "relationshipElement"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -1609,7 +1609,7 @@ class Test_SubmodelElementList(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "submodelElementList"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -1657,7 +1657,7 @@ class Test_SubmodelElementList(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 observed_exception: Optional[
                     aas_xmlization.DeserializationException
                 ] = None
@@ -1695,7 +1695,7 @@ class Test_SubmodelElementList(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 try:
                     container = aas_xmlization.environment_from_str(
                         path.read_text(encoding="utf-8")
@@ -1727,7 +1727,7 @@ class Test_SubmodelElementList(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "submodelElementList"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -1783,7 +1783,7 @@ class Test_SubmodelElementCollection(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "submodelElementCollection"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -1831,7 +1831,7 @@ class Test_SubmodelElementCollection(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 observed_exception: Optional[
                     aas_xmlization.DeserializationException
                 ] = None
@@ -1869,7 +1869,7 @@ class Test_SubmodelElementCollection(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 try:
                     container = aas_xmlization.environment_from_str(
                         path.read_text(encoding="utf-8")
@@ -1901,7 +1901,7 @@ class Test_SubmodelElementCollection(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "submodelElementCollection"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -1957,7 +1957,7 @@ class Test_Property(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "property"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -2005,7 +2005,7 @@ class Test_Property(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 observed_exception: Optional[
                     aas_xmlization.DeserializationException
                 ] = None
@@ -2043,7 +2043,7 @@ class Test_Property(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 try:
                     container = aas_xmlization.environment_from_str(
                         path.read_text(encoding="utf-8")
@@ -2075,7 +2075,7 @@ class Test_Property(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "property"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -2131,7 +2131,7 @@ class Test_MultiLanguageProperty(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "multiLanguageProperty"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -2179,7 +2179,7 @@ class Test_MultiLanguageProperty(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 observed_exception: Optional[
                     aas_xmlization.DeserializationException
                 ] = None
@@ -2217,7 +2217,7 @@ class Test_MultiLanguageProperty(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 try:
                     container = aas_xmlization.environment_from_str(
                         path.read_text(encoding="utf-8")
@@ -2249,7 +2249,7 @@ class Test_MultiLanguageProperty(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "multiLanguageProperty"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -2305,7 +2305,7 @@ class Test_Range(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "range"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -2353,7 +2353,7 @@ class Test_Range(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 observed_exception: Optional[
                     aas_xmlization.DeserializationException
                 ] = None
@@ -2391,7 +2391,7 @@ class Test_Range(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 try:
                     container = aas_xmlization.environment_from_str(
                         path.read_text(encoding="utf-8")
@@ -2423,7 +2423,7 @@ class Test_Range(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "range"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -2479,7 +2479,7 @@ class Test_ReferenceElement(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "referenceElement"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -2527,7 +2527,7 @@ class Test_ReferenceElement(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 observed_exception: Optional[
                     aas_xmlization.DeserializationException
                 ] = None
@@ -2565,7 +2565,7 @@ class Test_ReferenceElement(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 try:
                     container = aas_xmlization.environment_from_str(
                         path.read_text(encoding="utf-8")
@@ -2597,7 +2597,7 @@ class Test_ReferenceElement(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "referenceElement"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -2653,7 +2653,7 @@ class Test_Blob(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "blob"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -2701,7 +2701,7 @@ class Test_Blob(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 observed_exception: Optional[
                     aas_xmlization.DeserializationException
                 ] = None
@@ -2739,7 +2739,7 @@ class Test_Blob(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 try:
                     container = aas_xmlization.environment_from_str(
                         path.read_text(encoding="utf-8")
@@ -2771,7 +2771,7 @@ class Test_Blob(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "blob"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -2827,7 +2827,7 @@ class Test_File(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "file"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -2875,7 +2875,7 @@ class Test_File(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 observed_exception: Optional[
                     aas_xmlization.DeserializationException
                 ] = None
@@ -2913,7 +2913,7 @@ class Test_File(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 try:
                     container = aas_xmlization.environment_from_str(
                         path.read_text(encoding="utf-8")
@@ -2945,7 +2945,7 @@ class Test_File(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "file"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -3001,7 +3001,7 @@ class Test_AnnotatedRelationshipElement(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "annotatedRelationshipElement"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -3049,7 +3049,7 @@ class Test_AnnotatedRelationshipElement(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 observed_exception: Optional[
                     aas_xmlization.DeserializationException
                 ] = None
@@ -3087,7 +3087,7 @@ class Test_AnnotatedRelationshipElement(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 try:
                     container = aas_xmlization.environment_from_str(
                         path.read_text(encoding="utf-8")
@@ -3119,7 +3119,7 @@ class Test_AnnotatedRelationshipElement(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "annotatedRelationshipElement"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -3175,7 +3175,7 @@ class Test_Entity(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "entity"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -3223,7 +3223,7 @@ class Test_Entity(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 observed_exception: Optional[
                     aas_xmlization.DeserializationException
                 ] = None
@@ -3261,7 +3261,7 @@ class Test_Entity(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 try:
                     container = aas_xmlization.environment_from_str(
                         path.read_text(encoding="utf-8")
@@ -3293,7 +3293,7 @@ class Test_Entity(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "entity"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -3349,7 +3349,7 @@ class Test_EventPayload(unittest.TestCase):
                 / "SelfContained"
                 / "Expected"
                 / "eventPayload"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -3397,7 +3397,7 @@ class Test_EventPayload(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 observed_exception: Optional[
                     aas_xmlization.DeserializationException
                 ] = None
@@ -3435,7 +3435,7 @@ class Test_EventPayload(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 try:
                     instance = aas_xmlization.event_payload_from_str(
                         path.read_text(encoding="utf-8")
@@ -3467,7 +3467,7 @@ class Test_EventPayload(unittest.TestCase):
                 / "SelfContained"
                 / "Expected"
                 / "eventPayload"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -3525,7 +3525,7 @@ class Test_BasicEventElement(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "basicEventElement"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -3573,7 +3573,7 @@ class Test_BasicEventElement(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 observed_exception: Optional[
                     aas_xmlization.DeserializationException
                 ] = None
@@ -3611,7 +3611,7 @@ class Test_BasicEventElement(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 try:
                     container = aas_xmlization.environment_from_str(
                         path.read_text(encoding="utf-8")
@@ -3643,7 +3643,7 @@ class Test_BasicEventElement(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "basicEventElement"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -3699,7 +3699,7 @@ class Test_Operation(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "operation"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -3747,7 +3747,7 @@ class Test_Operation(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 observed_exception: Optional[
                     aas_xmlization.DeserializationException
                 ] = None
@@ -3785,7 +3785,7 @@ class Test_Operation(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 try:
                     container = aas_xmlization.environment_from_str(
                         path.read_text(encoding="utf-8")
@@ -3817,7 +3817,7 @@ class Test_Operation(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "operation"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -3873,7 +3873,7 @@ class Test_OperationVariable(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "operationVariable"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -3921,7 +3921,7 @@ class Test_OperationVariable(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 observed_exception: Optional[
                     aas_xmlization.DeserializationException
                 ] = None
@@ -3959,7 +3959,7 @@ class Test_OperationVariable(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 try:
                     container = aas_xmlization.environment_from_str(
                         path.read_text(encoding="utf-8")
@@ -3991,7 +3991,7 @@ class Test_OperationVariable(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "operationVariable"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -4047,7 +4047,7 @@ class Test_Capability(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "capability"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -4095,7 +4095,7 @@ class Test_Capability(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 observed_exception: Optional[
                     aas_xmlization.DeserializationException
                 ] = None
@@ -4133,7 +4133,7 @@ class Test_Capability(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 try:
                     container = aas_xmlization.environment_from_str(
                         path.read_text(encoding="utf-8")
@@ -4165,7 +4165,7 @@ class Test_Capability(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "capability"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -4221,7 +4221,7 @@ class Test_ConceptDescription(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "conceptDescription"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -4269,7 +4269,7 @@ class Test_ConceptDescription(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 observed_exception: Optional[
                     aas_xmlization.DeserializationException
                 ] = None
@@ -4307,7 +4307,7 @@ class Test_ConceptDescription(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 try:
                     container = aas_xmlization.environment_from_str(
                         path.read_text(encoding="utf-8")
@@ -4339,7 +4339,7 @@ class Test_ConceptDescription(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "conceptDescription"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -4395,7 +4395,7 @@ class Test_Reference(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "reference"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -4443,7 +4443,7 @@ class Test_Reference(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 observed_exception: Optional[
                     aas_xmlization.DeserializationException
                 ] = None
@@ -4481,7 +4481,7 @@ class Test_Reference(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 try:
                     container = aas_xmlization.environment_from_str(
                         path.read_text(encoding="utf-8")
@@ -4513,7 +4513,7 @@ class Test_Reference(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "reference"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -4569,7 +4569,7 @@ class Test_Key(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "key"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -4617,7 +4617,7 @@ class Test_Key(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 observed_exception: Optional[
                     aas_xmlization.DeserializationException
                 ] = None
@@ -4655,7 +4655,7 @@ class Test_Key(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 try:
                     container = aas_xmlization.environment_from_str(
                         path.read_text(encoding="utf-8")
@@ -4687,7 +4687,7 @@ class Test_Key(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "key"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -4743,7 +4743,7 @@ class Test_LangString(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "langString"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -4791,7 +4791,7 @@ class Test_LangString(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 observed_exception: Optional[
                     aas_xmlization.DeserializationException
                 ] = None
@@ -4829,7 +4829,7 @@ class Test_LangString(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 try:
                     container = aas_xmlization.environment_from_str(
                         path.read_text(encoding="utf-8")
@@ -4861,7 +4861,7 @@ class Test_LangString(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "langString"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -4917,7 +4917,7 @@ class Test_Environment(unittest.TestCase):
                 / "SelfContained"
                 / "Expected"
                 / "environment"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -4965,7 +4965,7 @@ class Test_Environment(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 observed_exception: Optional[
                     aas_xmlization.DeserializationException
                 ] = None
@@ -5003,7 +5003,7 @@ class Test_Environment(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 try:
                     instance = aas_xmlization.environment_from_str(
                         path.read_text(encoding="utf-8")
@@ -5035,7 +5035,7 @@ class Test_Environment(unittest.TestCase):
                 / "SelfContained"
                 / "Expected"
                 / "environment"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -5091,7 +5091,7 @@ class Test_EmbeddedDataSpecification(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "embeddedDataSpecification"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -5139,7 +5139,7 @@ class Test_EmbeddedDataSpecification(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 observed_exception: Optional[
                     aas_xmlization.DeserializationException
                 ] = None
@@ -5177,7 +5177,7 @@ class Test_EmbeddedDataSpecification(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 try:
                     container = aas_xmlization.environment_from_str(
                         path.read_text(encoding="utf-8")
@@ -5209,7 +5209,7 @@ class Test_EmbeddedDataSpecification(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "embeddedDataSpecification"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -5265,7 +5265,7 @@ class Test_ValueReferencePair(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "valueReferencePair"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -5313,7 +5313,7 @@ class Test_ValueReferencePair(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 observed_exception: Optional[
                     aas_xmlization.DeserializationException
                 ] = None
@@ -5351,7 +5351,7 @@ class Test_ValueReferencePair(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 try:
                     container = aas_xmlization.environment_from_str(
                         path.read_text(encoding="utf-8")
@@ -5383,7 +5383,7 @@ class Test_ValueReferencePair(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "valueReferencePair"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -5439,7 +5439,7 @@ class Test_ValueList(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "valueList"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -5487,7 +5487,7 @@ class Test_ValueList(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 observed_exception: Optional[
                     aas_xmlization.DeserializationException
                 ] = None
@@ -5525,7 +5525,7 @@ class Test_ValueList(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 try:
                     container = aas_xmlization.environment_from_str(
                         path.read_text(encoding="utf-8")
@@ -5557,7 +5557,7 @@ class Test_ValueList(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "valueList"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -5613,7 +5613,7 @@ class Test_DataSpecificationIEC61360(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "dataSpecificationIec61360"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -5661,7 +5661,7 @@ class Test_DataSpecificationIEC61360(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 observed_exception: Optional[
                     aas_xmlization.DeserializationException
                 ] = None
@@ -5699,7 +5699,7 @@ class Test_DataSpecificationIEC61360(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 try:
                     container = aas_xmlization.environment_from_str(
                         path.read_text(encoding="utf-8")
@@ -5731,7 +5731,7 @@ class Test_DataSpecificationIEC61360(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "dataSpecificationIec61360"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -5787,7 +5787,7 @@ class Test_DataSpecificationPhysicalUnit(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "dataSpecificationPhysicalUnit"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:
@@ -5835,7 +5835,7 @@ class Test_DataSpecificationPhysicalUnit(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 observed_exception: Optional[
                     aas_xmlization.DeserializationException
                 ] = None
@@ -5873,7 +5873,7 @@ class Test_DataSpecificationPhysicalUnit(unittest.TestCase):
                 # and this ``cause``.
                 continue
 
-            for path in sorted(base_dir.glob("*.xml")):
+            for path in sorted(base_dir.glob("**/*.xml")):
                 try:
                     container = aas_xmlization.environment_from_str(
                         path.read_text(encoding="utf-8")
@@ -5905,7 +5905,7 @@ class Test_DataSpecificationPhysicalUnit(unittest.TestCase):
                 / "ContainedInEnvironment"
                 / "Expected"
                 / "dataSpecificationPhysicalUnit"
-            ).glob("*.xml")
+            ).glob("**/*.xml")
         )
 
         for path in paths:


### PR DESCRIPTION
We did not recursively look for example files in the test data. Instead, we only looked at the first-level directory.

This patch makes the test scripts look recursively by globbing ``**/*.json or xml``.

As soon as we fixed the search, a couple of serious errors were revealed. We fixed the issues in aas-core-codegen. Notably, these changes were relevant:

* [aas-core-codegen 3fea5b26]
* [aas-core-codegen e2a7a806]

Please see the changes in aas-core-codegen if you need more details on the issues.

[aas-core-codegen 3fea5b26]: https://github.com/aas-core-works/aas-core-codegen/commit/3fea5b26
[aas-core-codegen e2a7a806]: https://github.com/aas-core-works/aas-core-codegen/commit/e2a7a806