### PR TITLE
Release 1.0.0rc2

### DIFF
--- a/aas_core3_rc02/__init__.py
+++ b/aas_core3_rc02/__init__.py
@@ -1,7 +1,7 @@
 """Manipulate, verify and de/serialize Asset Administration Shells."""
 
 # Synchronize with __init__.py and changelog.rst!
-__version__ = "1.0.0rc1"
+__version__ = "1.0.0rc2"
 __author__ = "Marko Ristin"
 __copyright__ = (
     "2022 Zurich University of Applied Sciences, Institute of Mechatronic Systems (IMS)"

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,6 +2,27 @@
 Change Log
 **********
 
+1.0.0rc2 (2022-10-30)
+=====================
+* Fix escaping in XML serialization.
+
+  Notably, ``&`` was mistakenly escaped to ``&amp`` instead of ``&amp;``.
+* Fix issues in verification of dates and other XML data types:
+
+    * We checked ``matches_*(value) is not None``, while ``matches_*`` returns a boolean.
+      Therefore, the checks against the patterns were outright ignored in the code.
+
+    * We fix the verification of ``xs:float`` for infinity.
+      This means that overflows are now correctly detected if the value is not a proper ``INF``.
+
+    * We disallow floating-point numbers in exponents in ``xs:float`` and ``xs:double``,
+      see also: `aas-core-meta b2d1230`.
+
+    * We disallow ``+INF`` as plus sign is not allowed in XML, see also `aas-core-meta a8e6621`
+
+.. _aas-core-meta b2d1230: https://github.com/aas-core-works/aas-core-meta/commit/b2d1230
+.. _aas-core-meta a8e6621: https://github.com/aas-core-works/aas-core-meta/commit/a8e6621
+
 1.0.0rc1 (2022-10-29)
 =======================
 * Initial version, ready for the very first review

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open(os.path.join(here, "README.rst"), encoding="utf-8") as fid:
 setup(
     name="aas-core3.0rc02",
     # Synchronize with __init__.py and changelog.rst!
-    version="1.0.0rc1",
+    version="1.0.0rc2",
     description="Manipulate, verify and de/serialize Asset Administration Shells.",
     long_description=long_description,
     url="https://github.com/aas-core-works/aas-core3.0rc02-python",


### PR DESCRIPTION
* Fix escaping in XML serialization.

  Notably, ``&`` was mistakenly escaped to ``&amp`` instead of ``&amp;``.
* Fix issues in verification of dates and other XML data types:

    * We checked ``matches_*(value) is not None``, while ``matches_*`` returns a boolean.
      Therefore, the checks against the patterns were outright ignored in the code.

    * We fix the verification of ``xs:float`` for infinity.
      This means that overflows are now correctly detected if the value is not a proper ``INF``.

    * We disallow floating-point numbers in exponents in ``xs:float`` and ``xs:double``,
      see also: [aas-core-meta b2d1230].

    * We disallow ``+INF`` as plus sign is not allowed in XML, see also [aas-core-meta a8e6621].

[aas-core-meta b2d1230]: https://github.com/aas-core-works/aas-core-meta/commit/b2d1230
[aas-core-meta a8e6621]: https://github.com/aas-core-works/aas-core-meta/commit/a8e6621