### PR TITLE
Sync naming with the published schemas for V3RC02

### DIFF
--- a/aas_core3_rc02/jsonization.py
+++ b/aas_core3_rc02/jsonization.py
@@ -245,7 +245,7 @@ class _SetterForExtension:
         self.semantic_id: Optional[aas_types.Reference] = None
         self.supplemental_semantic_ids: Optional[List[aas_types.Reference]] = None
         self.name: Optional[str] = None
-        self.value_type: Optional[aas_types.DataTypeDefXSD] = None
+        self.value_type: Optional[aas_types.DataTypeDefXsd] = None
         self.value: Optional[str] = None
         self.refers_to: Optional[aas_types.Reference] = None
 
@@ -691,7 +691,7 @@ class _SetterForQualifier:
         self.supplemental_semantic_ids: Optional[List[aas_types.Reference]] = None
         self.kind: Optional[aas_types.QualifierKind] = None
         self.type: Optional[str] = None
-        self.value_type: Optional[aas_types.DataTypeDefXSD] = None
+        self.value_type: Optional[aas_types.DataTypeDefXsd] = None
         self.value: Optional[str] = None
         self.value_id: Optional[aas_types.Reference] = None
 
@@ -1997,10 +1997,10 @@ def _relationship_element_from_jsonable_without_dispatch(
 
 def aas_submodel_elements_from_jsonable(
     jsonable: Jsonable,
-) -> aas_types.AASSubmodelElements:
+) -> aas_types.AasSubmodelElements:
     """
     Convert the JSON-able structure :paramref:`jsonable` to a literal of
-    :py:class:`.types.AASSubmodelElements`.
+    :py:class:`.types.AasSubmodelElements`.
 
     :param jsonable: JSON-able structure to be parsed
     :return: parsed literal
@@ -2013,7 +2013,7 @@ def aas_submodel_elements_from_jsonable(
     if literal is None:
         raise DeserializationException(
             f"Not a valid string representation of "
-            f"a literal of AASSubmodelElements: {jsonable}"
+            f"a literal of AasSubmodelElements: {jsonable}"
         )
 
     return literal
@@ -2040,8 +2040,8 @@ class _SetterForSubmodelElementList:
         self.order_relevant: Optional[bool] = None
         self.value: Optional[List[aas_types.SubmodelElement]] = None
         self.semantic_id_list_element: Optional[aas_types.Reference] = None
-        self.type_value_list_element: Optional[aas_types.AASSubmodelElements] = None
-        self.value_type_list_element: Optional[aas_types.DataTypeDefXSD] = None
+        self.type_value_list_element: Optional[aas_types.AasSubmodelElements] = None
+        self.value_type_list_element: Optional[aas_types.DataTypeDefXsd] = None
 
     def ignore(self, jsonable: Jsonable) -> None:
         """Ignore :paramref:`jsonable` and do not set anything."""
@@ -2656,7 +2656,7 @@ class _SetterForProperty:
         self.embedded_data_specifications: Optional[
             List[aas_types.EmbeddedDataSpecification]
         ] = None
-        self.value_type: Optional[aas_types.DataTypeDefXSD] = None
+        self.value_type: Optional[aas_types.DataTypeDefXsd] = None
         self.value: Optional[str] = None
         self.value_id: Optional[aas_types.Reference] = None
 
@@ -3214,7 +3214,7 @@ class _SetterForRange:
         self.embedded_data_specifications: Optional[
             List[aas_types.EmbeddedDataSpecification]
         ] = None
-        self.value_type: Optional[aas_types.DataTypeDefXSD] = None
+        self.value_type: Optional[aas_types.DataTypeDefXsd] = None
         self.min: Optional[str] = None
         self.max: Optional[str] = None
 
@@ -6456,10 +6456,10 @@ def key_types_from_jsonable(jsonable: Jsonable) -> aas_types.KeyTypes:
     return literal
 
 
-def data_type_def_xsd_from_jsonable(jsonable: Jsonable) -> aas_types.DataTypeDefXSD:
+def data_type_def_xsd_from_jsonable(jsonable: Jsonable) -> aas_types.DataTypeDefXsd:
     """
     Convert the JSON-able structure :paramref:`jsonable` to a literal of
-    :py:class:`.types.DataTypeDefXSD`.
+    :py:class:`.types.DataTypeDefXsd`.
 
     :param jsonable: JSON-able structure to be parsed
     :return: parsed literal
@@ -6472,7 +6472,7 @@ def data_type_def_xsd_from_jsonable(jsonable: Jsonable) -> aas_types.DataTypeDef
     if literal is None:
         raise DeserializationException(
             f"Not a valid string representation of "
-            f"a literal of DataTypeDefXSD: {jsonable}"
+            f"a literal of DataTypeDefXsd: {jsonable}"
         )
 
     return literal

--- a/aas_core3_rc02/stringification.py
+++ b/aas_core3_rc02/stringification.py
@@ -80,40 +80,40 @@ def asset_kind_from_str(text: str) -> Optional[aas_types.AssetKind]:
     return _ASSET_KIND_FROM_STR.get(text, None)
 
 
-_AAS_SUBMODEL_ELEMENTS_FROM_STR: Mapping[str, aas_types.AASSubmodelElements] = {
-    "AnnotatedRelationshipElement": aas_types.AASSubmodelElements.ANNOTATED_RELATIONSHIP_ELEMENT,
-    "BasicEventElement": aas_types.AASSubmodelElements.BASIC_EVENT_ELEMENT,
-    "Blob": aas_types.AASSubmodelElements.BLOB,
-    "Capability": aas_types.AASSubmodelElements.CAPABILITY,
-    "DataElement": aas_types.AASSubmodelElements.DATA_ELEMENT,
-    "Entity": aas_types.AASSubmodelElements.ENTITY,
-    "EventElement": aas_types.AASSubmodelElements.EVENT_ELEMENT,
-    "File": aas_types.AASSubmodelElements.FILE,
-    "MultiLanguageProperty": aas_types.AASSubmodelElements.MULTI_LANGUAGE_PROPERTY,
-    "Operation": aas_types.AASSubmodelElements.OPERATION,
-    "Property": aas_types.AASSubmodelElements.PROPERTY,
-    "Range": aas_types.AASSubmodelElements.RANGE,
-    "ReferenceElement": aas_types.AASSubmodelElements.REFERENCE_ELEMENT,
-    "RelationshipElement": aas_types.AASSubmodelElements.RELATIONSHIP_ELEMENT,
-    "SubmodelElement": aas_types.AASSubmodelElements.SUBMODEL_ELEMENT,
-    "SubmodelElementList": aas_types.AASSubmodelElements.SUBMODEL_ELEMENT_LIST,
-    "SubmodelElementCollection": aas_types.AASSubmodelElements.SUBMODEL_ELEMENT_COLLECTION,
+_AAS_SUBMODEL_ELEMENTS_FROM_STR: Mapping[str, aas_types.AasSubmodelElements] = {
+    "AnnotatedRelationshipElement": aas_types.AasSubmodelElements.ANNOTATED_RELATIONSHIP_ELEMENT,
+    "BasicEventElement": aas_types.AasSubmodelElements.BASIC_EVENT_ELEMENT,
+    "Blob": aas_types.AasSubmodelElements.BLOB,
+    "Capability": aas_types.AasSubmodelElements.CAPABILITY,
+    "DataElement": aas_types.AasSubmodelElements.DATA_ELEMENT,
+    "Entity": aas_types.AasSubmodelElements.ENTITY,
+    "EventElement": aas_types.AasSubmodelElements.EVENT_ELEMENT,
+    "File": aas_types.AasSubmodelElements.FILE,
+    "MultiLanguageProperty": aas_types.AasSubmodelElements.MULTI_LANGUAGE_PROPERTY,
+    "Operation": aas_types.AasSubmodelElements.OPERATION,
+    "Property": aas_types.AasSubmodelElements.PROPERTY,
+    "Range": aas_types.AasSubmodelElements.RANGE,
+    "ReferenceElement": aas_types.AasSubmodelElements.REFERENCE_ELEMENT,
+    "RelationshipElement": aas_types.AasSubmodelElements.RELATIONSHIP_ELEMENT,
+    "SubmodelElement": aas_types.AasSubmodelElements.SUBMODEL_ELEMENT,
+    "SubmodelElementList": aas_types.AasSubmodelElements.SUBMODEL_ELEMENT_LIST,
+    "SubmodelElementCollection": aas_types.AasSubmodelElements.SUBMODEL_ELEMENT_COLLECTION,
 }
 
 
 def aas_submodel_elements_from_str(
     text: str,
-) -> Optional[aas_types.AASSubmodelElements]:
+) -> Optional[aas_types.AasSubmodelElements]:
     """
     Parse :paramref:`text` as string representation
-    of :py:class:`aas_core3_rc02.AASSubmodelElements`.
+    of :py:class:`aas_core3_rc02.AasSubmodelElements`.
 
     If :paramref:`text` is not a valid string representation of a literal
-    of :py:class:`aas_core3_rc02.AASSubmodelElements`, return ``None``.
+    of :py:class:`aas_core3_rc02.AasSubmodelElements`, return ``None``.
 
     :param text: to be parsed
     :return:
-        the corresponding literal of :py:class:`aas_core3_rc02.AASSubmodelElements`
+        the corresponding literal of :py:class:`aas_core3_rc02.AasSubmodelElements`
         or ``None``, if :paramref:`text` invalid.
     """
     return _AAS_SUBMODEL_ELEMENTS_FROM_STR.get(text, None)
@@ -251,54 +251,54 @@ def key_types_from_str(text: str) -> Optional[aas_types.KeyTypes]:
     return _KEY_TYPES_FROM_STR.get(text, None)
 
 
-_DATA_TYPE_DEF_XSD_FROM_STR: Mapping[str, aas_types.DataTypeDefXSD] = {
-    "xs:anyURI": aas_types.DataTypeDefXSD.ANY_URI,
-    "xs:base64Binary": aas_types.DataTypeDefXSD.BASE_64_BINARY,
-    "xs:boolean": aas_types.DataTypeDefXSD.BOOLEAN,
-    "xs:date": aas_types.DataTypeDefXSD.DATE,
-    "xs:dateTime": aas_types.DataTypeDefXSD.DATE_TIME,
-    "xs:dateTimeStamp": aas_types.DataTypeDefXSD.DATE_TIME_STAMP,
-    "xs:decimal": aas_types.DataTypeDefXSD.DECIMAL,
-    "xs:double": aas_types.DataTypeDefXSD.DOUBLE,
-    "xs:duration": aas_types.DataTypeDefXSD.DURATION,
-    "xs:float": aas_types.DataTypeDefXSD.FLOAT,
-    "xs:gDay": aas_types.DataTypeDefXSD.G_DAY,
-    "xs:gMonth": aas_types.DataTypeDefXSD.G_MONTH,
-    "xs:gMonthDay": aas_types.DataTypeDefXSD.G_MONTH_DAY,
-    "xs:gYear": aas_types.DataTypeDefXSD.G_YEAR,
-    "xs:gYearMonth": aas_types.DataTypeDefXSD.G_YEAR_MONTH,
-    "xs:hexBinary": aas_types.DataTypeDefXSD.HEX_BINARY,
-    "xs:string": aas_types.DataTypeDefXSD.STRING,
-    "xs:time": aas_types.DataTypeDefXSD.TIME,
-    "xs:dayTimeDuration": aas_types.DataTypeDefXSD.DAY_TIME_DURATION,
-    "xs:yearMonthDuration": aas_types.DataTypeDefXSD.YEAR_MONTH_DURATION,
-    "xs:integer": aas_types.DataTypeDefXSD.INTEGER,
-    "xs:long": aas_types.DataTypeDefXSD.LONG,
-    "xs:int": aas_types.DataTypeDefXSD.INT,
-    "xs:short": aas_types.DataTypeDefXSD.SHORT,
-    "xs:byte": aas_types.DataTypeDefXSD.BYTE,
-    "xs:nonNegativeInteger": aas_types.DataTypeDefXSD.NON_NEGATIVE_INTEGER,
-    "xs:positiveInteger": aas_types.DataTypeDefXSD.POSITIVE_INTEGER,
-    "xs:unsignedLong": aas_types.DataTypeDefXSD.UNSIGNED_LONG,
-    "xs:unsignedInt": aas_types.DataTypeDefXSD.UNSIGNED_INT,
-    "xs:unsignedShort": aas_types.DataTypeDefXSD.UNSIGNED_SHORT,
-    "xs:unsignedByte": aas_types.DataTypeDefXSD.UNSIGNED_BYTE,
-    "xs:nonPositiveInteger": aas_types.DataTypeDefXSD.NON_POSITIVE_INTEGER,
-    "xs:negativeInteger": aas_types.DataTypeDefXSD.NEGATIVE_INTEGER,
+_DATA_TYPE_DEF_XSD_FROM_STR: Mapping[str, aas_types.DataTypeDefXsd] = {
+    "xs:anyURI": aas_types.DataTypeDefXsd.ANY_URI,
+    "xs:base64Binary": aas_types.DataTypeDefXsd.BASE_64_BINARY,
+    "xs:boolean": aas_types.DataTypeDefXsd.BOOLEAN,
+    "xs:date": aas_types.DataTypeDefXsd.DATE,
+    "xs:dateTime": aas_types.DataTypeDefXsd.DATE_TIME,
+    "xs:dateTimeStamp": aas_types.DataTypeDefXsd.DATE_TIME_STAMP,
+    "xs:decimal": aas_types.DataTypeDefXsd.DECIMAL,
+    "xs:double": aas_types.DataTypeDefXsd.DOUBLE,
+    "xs:duration": aas_types.DataTypeDefXsd.DURATION,
+    "xs:float": aas_types.DataTypeDefXsd.FLOAT,
+    "xs:gDay": aas_types.DataTypeDefXsd.G_DAY,
+    "xs:gMonth": aas_types.DataTypeDefXsd.G_MONTH,
+    "xs:gMonthDay": aas_types.DataTypeDefXsd.G_MONTH_DAY,
+    "xs:gYear": aas_types.DataTypeDefXsd.G_YEAR,
+    "xs:gYearMonth": aas_types.DataTypeDefXsd.G_YEAR_MONTH,
+    "xs:hexBinary": aas_types.DataTypeDefXsd.HEX_BINARY,
+    "xs:string": aas_types.DataTypeDefXsd.STRING,
+    "xs:time": aas_types.DataTypeDefXsd.TIME,
+    "xs:dayTimeDuration": aas_types.DataTypeDefXsd.DAY_TIME_DURATION,
+    "xs:yearMonthDuration": aas_types.DataTypeDefXsd.YEAR_MONTH_DURATION,
+    "xs:integer": aas_types.DataTypeDefXsd.INTEGER,
+    "xs:long": aas_types.DataTypeDefXsd.LONG,
+    "xs:int": aas_types.DataTypeDefXsd.INT,
+    "xs:short": aas_types.DataTypeDefXsd.SHORT,
+    "xs:byte": aas_types.DataTypeDefXsd.BYTE,
+    "xs:nonNegativeInteger": aas_types.DataTypeDefXsd.NON_NEGATIVE_INTEGER,
+    "xs:positiveInteger": aas_types.DataTypeDefXsd.POSITIVE_INTEGER,
+    "xs:unsignedLong": aas_types.DataTypeDefXsd.UNSIGNED_LONG,
+    "xs:unsignedInt": aas_types.DataTypeDefXsd.UNSIGNED_INT,
+    "xs:unsignedShort": aas_types.DataTypeDefXsd.UNSIGNED_SHORT,
+    "xs:unsignedByte": aas_types.DataTypeDefXsd.UNSIGNED_BYTE,
+    "xs:nonPositiveInteger": aas_types.DataTypeDefXsd.NON_POSITIVE_INTEGER,
+    "xs:negativeInteger": aas_types.DataTypeDefXsd.NEGATIVE_INTEGER,
 }
 
 
-def data_type_def_xsd_from_str(text: str) -> Optional[aas_types.DataTypeDefXSD]:
+def data_type_def_xsd_from_str(text: str) -> Optional[aas_types.DataTypeDefXsd]:
     """
     Parse :paramref:`text` as string representation
-    of :py:class:`aas_core3_rc02.DataTypeDefXSD`.
+    of :py:class:`aas_core3_rc02.DataTypeDefXsd`.
 
     If :paramref:`text` is not a valid string representation of a literal
-    of :py:class:`aas_core3_rc02.DataTypeDefXSD`, return ``None``.
+    of :py:class:`aas_core3_rc02.DataTypeDefXsd`, return ``None``.
 
     :param text: to be parsed
     :return:
-        the corresponding literal of :py:class:`aas_core3_rc02.DataTypeDefXSD`
+        the corresponding literal of :py:class:`aas_core3_rc02.DataTypeDefXsd`
         or ``None``, if :paramref:`text` invalid.
     """
     return _DATA_TYPE_DEF_XSD_FROM_STR.get(text, None)

--- a/aas_core3_rc02/types.py
+++ b/aas_core3_rc02/types.py
@@ -32,20 +32,20 @@ between the properties and the sets is defined through invariants. This causes
 the following divergences:
 
 * We decided therefore to remove the enumerations ``DataTypeDef`` and ``DataTypeDefRDF``
-  and keep only :py:class:`DataTypeDefXSD` as enumeration. Otherwise, we would have
+  and keep only :py:class:`DataTypeDefXsd` as enumeration. Otherwise, we would have
   to write redundant invariants all over the meta-model because ``DataTypeDef`` and
   ``DataTypeDefRDF`` are actually never used in any type definition.
-* The enumeration :py:class:`AASSubmodelElements` is used in two different contexts.
+* The enumeration :py:class:`AasSubmodelElements` is used in two different contexts.
   One context is the definition of key types in a reference. Another context is
   the definition of element types in a :py:class:`SubmodelElementList`. It is very
   counter-intuitive to see the type of
   :py:attr:`SubmodelElementList.type_value_list_element` as
   :py:class:`KeyTypes` even though an invariant might specify that it is an element of
-  :py:class:`AASSubmodelElements`.
+  :py:class:`AasSubmodelElements`.
 
   To avoid confusion, we introduce a set of :py:class:`KeyTypes`,
   :py:attr:`.constants.AAS_SUBMODEL_ELEMENTS_AS_KEYS` to represent the first context (key type
-  in a reference). The enumeration :py:class:`AASSubmodelElements` is kept as designator
+  in a reference). The enumeration :py:class:`AasSubmodelElements` is kept as designator
   for :py:attr:`SubmodelElementList.type_value_list_element`.
 
 Concerning the data specifications, we embed them within
@@ -204,8 +204,8 @@ class Extension(HasSemantics):
 
     #: Type of the value of the extension.
     #:
-    #: Default: :py:attr:`DataTypeDefXSD.STRING`
-    value_type: Optional["DataTypeDefXSD"]
+    #: Default: :py:attr:`DataTypeDefXsd.STRING`
+    value_type: Optional["DataTypeDefXsd"]
 
     #: Value of the extension
     value: Optional[str]
@@ -213,9 +213,9 @@ class Extension(HasSemantics):
     #: Reference to an element the extension refers to.
     refers_to: Optional["Reference"]
 
-    def value_type_or_default(self) -> "DataTypeDefXSD":
+    def value_type_or_default(self) -> "DataTypeDefXsd":
         """Return the :py:attr:`value_type` if set, or the default otherwise."""
-        return self.value_type if self.value_type is not None else DataTypeDefXSD.STRING
+        return self.value_type if self.value_type is not None else DataTypeDefXsd.STRING
 
     def descend_once(self) -> Iterator[Class]:
         """
@@ -285,7 +285,7 @@ class Extension(HasSemantics):
         name: str,
         semantic_id: Optional["Reference"] = None,
         supplemental_semantic_ids: Optional[List["Reference"]] = None,
-        value_type: Optional["DataTypeDefXSD"] = None,
+        value_type: Optional["DataTypeDefXsd"] = None,
         value: Optional[str] = None,
         refers_to: Optional["Reference"] = None,
     ) -> None:
@@ -694,7 +694,7 @@ class Qualifier(HasSemantics):
     type: str
 
     #: Data type of the qualifier value.
-    value_type: "DataTypeDefXSD"
+    value_type: "DataTypeDefXsd"
 
     #: The qualifier value is the value of the qualifier.
     value: Optional[str]
@@ -776,7 +776,7 @@ class Qualifier(HasSemantics):
     def __init__(
         self,
         type: str,
-        value_type: "DataTypeDefXSD",
+        value_type: "DataTypeDefXsd",
         semantic_id: Optional["Reference"] = None,
         supplemental_semantic_ids: Optional[List["Reference"]] = None,
         kind: Optional["QualifierKind"] = None,
@@ -1652,7 +1652,7 @@ class RelationshipElement(SubmodelElement):
         self.second = second
 
 
-class AASSubmodelElements(enum.Enum):
+class AasSubmodelElements(enum.Enum):
     """
     Enumeration of all possible elements of a :py:class:`SubmodelElementList`.
     """
@@ -1728,8 +1728,8 @@ class SubmodelElementList(SubmodelElement):
         .. _constraint_AASd-109:
 
         If :py:attr:`type_value_list_element` is equal to
-        :py:attr:`AASSubmodelElements.PROPERTY` or
-        :py:attr:`AASSubmodelElements.RANGE`
+        :py:attr:`AasSubmodelElements.PROPERTY` or
+        :py:attr:`AasSubmodelElements.RANGE`
         :py:attr:`value_type_list_element` shall be set and all first
         level child elements in the :py:class:`SubmodelElementList` shall have
         the value type as specified in :py:attr:`value_type_list_element`.
@@ -1754,10 +1754,10 @@ class SubmodelElementList(SubmodelElement):
     semantic_id_list_element: Optional["Reference"]
 
     #: The submodel element type of the submodel elements contained in the list.
-    type_value_list_element: "AASSubmodelElements"
+    type_value_list_element: "AasSubmodelElements"
 
     #: The value type of the submodel element contained in the list.
-    value_type_list_element: Optional["DataTypeDefXSD"]
+    value_type_list_element: Optional["DataTypeDefXsd"]
 
     def over_value_or_empty(self) -> Iterator["SubmodelElement"]:
         """Yield from :py:attr:`.value` if set."""
@@ -1887,7 +1887,7 @@ class SubmodelElementList(SubmodelElement):
 
     def __init__(
         self,
-        type_value_list_element: "AASSubmodelElements",
+        type_value_list_element: "AasSubmodelElements",
         extensions: Optional[List["Extension"]] = None,
         category: Optional[str] = None,
         id_short: Optional[str] = None,
@@ -1904,7 +1904,7 @@ class SubmodelElementList(SubmodelElement):
         order_relevant: Optional[bool] = None,
         value: Optional[List["SubmodelElement"]] = None,
         semantic_id_list_element: Optional["Reference"] = None,
-        value_type_list_element: Optional["DataTypeDefXSD"] = None,
+        value_type_list_element: Optional["DataTypeDefXsd"] = None,
     ) -> None:
         """Initialize with the given values."""
         SubmodelElement.__init__(
@@ -2155,7 +2155,7 @@ class Property(DataElement):
     """
 
     #: Data type of the value
-    value_type: "DataTypeDefXSD"
+    value_type: "DataTypeDefXsd"
 
     #: The value of the property instance.
     value: Optional[str]
@@ -2277,7 +2277,7 @@ class Property(DataElement):
 
     def __init__(
         self,
-        value_type: "DataTypeDefXSD",
+        value_type: "DataTypeDefXsd",
         extensions: Optional[List["Extension"]] = None,
         category: Optional[str] = None,
         id_short: Optional[str] = None,
@@ -2501,7 +2501,7 @@ class Range(DataElement):
     """
 
     #: Data type of the min und max
-    value_type: "DataTypeDefXSD"
+    value_type: "DataTypeDefXsd"
 
     #: The minimum value of the range.
     #:
@@ -2615,7 +2615,7 @@ class Range(DataElement):
 
     def __init__(
         self,
-        value_type: "DataTypeDefXSD",
+        value_type: "DataTypeDefXsd",
         extensions: Optional[List["Extension"]] = None,
         category: Optional[str] = None,
         id_short: Optional[str] = None,
@@ -4889,7 +4889,7 @@ class KeyTypes(enum.Enum):
     SUBMODEL_ELEMENT_COLLECTION = "SubmodelElementCollection"
 
 
-class DataTypeDefXSD(enum.Enum):
+class DataTypeDefXsd(enum.Enum):
     """Enumeration listing all xsd anySimpleTypes"""
 
     ANY_URI = "xs:anyURI"

--- a/aas_core3_rc02/verification.py
+++ b/aas_core3_rc02/verification.py
@@ -1493,50 +1493,50 @@ def is_xs_unsigned_byte(value: str) -> bool:
 
 
 _DATA_TYPE_DEF_XSD_TO_VALUE_CONSISTENCY: Mapping[
-    aas_types.DataTypeDefXSD, Callable[[str], bool]
+    aas_types.DataTypeDefXsd, Callable[[str], bool]
 ] = {
-    aas_types.DataTypeDefXSD.ANY_URI: matches_xs_any_uri,
-    aas_types.DataTypeDefXSD.BASE_64_BINARY: matches_xs_base_64_binary,
-    aas_types.DataTypeDefXSD.BOOLEAN: matches_xs_boolean,
-    aas_types.DataTypeDefXSD.DATE: is_xs_date,
-    aas_types.DataTypeDefXSD.DATE_TIME: is_xs_date_time,
-    aas_types.DataTypeDefXSD.DATE_TIME_STAMP: is_xs_date_time_stamp,
-    aas_types.DataTypeDefXSD.DECIMAL: matches_xs_decimal,
-    aas_types.DataTypeDefXSD.DOUBLE: is_xs_double,
-    aas_types.DataTypeDefXSD.DURATION: matches_xs_duration,
-    aas_types.DataTypeDefXSD.FLOAT: is_xs_float,
-    aas_types.DataTypeDefXSD.G_DAY: matches_xs_g_day,
-    aas_types.DataTypeDefXSD.G_MONTH: matches_xs_g_month,
-    aas_types.DataTypeDefXSD.G_MONTH_DAY: is_xs_g_month_day,
-    aas_types.DataTypeDefXSD.G_YEAR: matches_xs_g_year,
-    aas_types.DataTypeDefXSD.G_YEAR_MONTH: matches_xs_g_year_month,
-    aas_types.DataTypeDefXSD.HEX_BINARY: matches_xs_hex_binary,
-    aas_types.DataTypeDefXSD.STRING: matches_xs_string,
-    aas_types.DataTypeDefXSD.TIME: matches_xs_time,
-    aas_types.DataTypeDefXSD.DAY_TIME_DURATION: matches_xs_day_time_duration,
-    aas_types.DataTypeDefXSD.YEAR_MONTH_DURATION: matches_xs_year_month_duration,
-    aas_types.DataTypeDefXSD.INTEGER: matches_xs_integer,
-    aas_types.DataTypeDefXSD.LONG: is_xs_long,
-    aas_types.DataTypeDefXSD.INT: is_xs_int,
-    aas_types.DataTypeDefXSD.SHORT: is_xs_short,
-    aas_types.DataTypeDefXSD.BYTE: is_xs_byte,
-    aas_types.DataTypeDefXSD.NON_NEGATIVE_INTEGER: matches_xs_non_negative_integer,
-    aas_types.DataTypeDefXSD.POSITIVE_INTEGER: matches_xs_positive_integer,
-    aas_types.DataTypeDefXSD.UNSIGNED_LONG: is_xs_unsigned_long,
-    aas_types.DataTypeDefXSD.UNSIGNED_INT: is_xs_unsigned_int,
-    aas_types.DataTypeDefXSD.UNSIGNED_SHORT: is_xs_unsigned_short,
-    aas_types.DataTypeDefXSD.UNSIGNED_BYTE: is_xs_unsigned_byte,
-    aas_types.DataTypeDefXSD.NON_POSITIVE_INTEGER: matches_xs_non_positive_integer,
-    aas_types.DataTypeDefXSD.NEGATIVE_INTEGER: matches_xs_negative_integer,
+    aas_types.DataTypeDefXsd.ANY_URI: matches_xs_any_uri,
+    aas_types.DataTypeDefXsd.BASE_64_BINARY: matches_xs_base_64_binary,
+    aas_types.DataTypeDefXsd.BOOLEAN: matches_xs_boolean,
+    aas_types.DataTypeDefXsd.DATE: is_xs_date,
+    aas_types.DataTypeDefXsd.DATE_TIME: is_xs_date_time,
+    aas_types.DataTypeDefXsd.DATE_TIME_STAMP: is_xs_date_time_stamp,
+    aas_types.DataTypeDefXsd.DECIMAL: matches_xs_decimal,
+    aas_types.DataTypeDefXsd.DOUBLE: is_xs_double,
+    aas_types.DataTypeDefXsd.DURATION: matches_xs_duration,
+    aas_types.DataTypeDefXsd.FLOAT: is_xs_float,
+    aas_types.DataTypeDefXsd.G_DAY: matches_xs_g_day,
+    aas_types.DataTypeDefXsd.G_MONTH: matches_xs_g_month,
+    aas_types.DataTypeDefXsd.G_MONTH_DAY: is_xs_g_month_day,
+    aas_types.DataTypeDefXsd.G_YEAR: matches_xs_g_year,
+    aas_types.DataTypeDefXsd.G_YEAR_MONTH: matches_xs_g_year_month,
+    aas_types.DataTypeDefXsd.HEX_BINARY: matches_xs_hex_binary,
+    aas_types.DataTypeDefXsd.STRING: matches_xs_string,
+    aas_types.DataTypeDefXsd.TIME: matches_xs_time,
+    aas_types.DataTypeDefXsd.DAY_TIME_DURATION: matches_xs_day_time_duration,
+    aas_types.DataTypeDefXsd.YEAR_MONTH_DURATION: matches_xs_year_month_duration,
+    aas_types.DataTypeDefXsd.INTEGER: matches_xs_integer,
+    aas_types.DataTypeDefXsd.LONG: is_xs_long,
+    aas_types.DataTypeDefXsd.INT: is_xs_int,
+    aas_types.DataTypeDefXsd.SHORT: is_xs_short,
+    aas_types.DataTypeDefXsd.BYTE: is_xs_byte,
+    aas_types.DataTypeDefXsd.NON_NEGATIVE_INTEGER: matches_xs_non_negative_integer,
+    aas_types.DataTypeDefXsd.POSITIVE_INTEGER: matches_xs_positive_integer,
+    aas_types.DataTypeDefXsd.UNSIGNED_LONG: is_xs_unsigned_long,
+    aas_types.DataTypeDefXsd.UNSIGNED_INT: is_xs_unsigned_int,
+    aas_types.DataTypeDefXsd.UNSIGNED_SHORT: is_xs_unsigned_short,
+    aas_types.DataTypeDefXsd.UNSIGNED_BYTE: is_xs_unsigned_byte,
+    aas_types.DataTypeDefXsd.NON_POSITIVE_INTEGER: matches_xs_non_positive_integer,
+    aas_types.DataTypeDefXsd.NEGATIVE_INTEGER: matches_xs_negative_integer,
 }
 assert all(
     data_type_def_xsd in _DATA_TYPE_DEF_XSD_TO_VALUE_CONSISTENCY
-    for data_type_def_xsd in aas_types.DataTypeDefXSD
+    for data_type_def_xsd in aas_types.DataTypeDefXsd
 )
 
 
 def value_consistent_with_xsd_type(
-    value: str, value_type: aas_types.DataTypeDefXSD
+    value: str, value_type: aas_types.DataTypeDefXsd
 ) -> bool:
     """
     Check that :paramref:`value` is consistent with the given
@@ -1661,58 +1661,58 @@ def submodel_elements_have_identical_semantic_ids(
 
 # fmt: off
 _AAS_SUBMODEL_ELEMENTS_TO_TYPE: Mapping[
-    aas_types.AASSubmodelElements,
+    aas_types.AasSubmodelElements,
     type
 ] = {
-    aas_types.AASSubmodelElements.ANNOTATED_RELATIONSHIP_ELEMENT:
+    aas_types.AasSubmodelElements.ANNOTATED_RELATIONSHIP_ELEMENT:
         aas_types.AnnotatedRelationshipElement,
 
-    aas_types.AASSubmodelElements.BASIC_EVENT_ELEMENT:
+    aas_types.AasSubmodelElements.BASIC_EVENT_ELEMENT:
         aas_types.BasicEventElement,
 
-    aas_types.AASSubmodelElements.BLOB:
+    aas_types.AasSubmodelElements.BLOB:
         aas_types.Blob,
 
-    aas_types.AASSubmodelElements.CAPABILITY:
+    aas_types.AasSubmodelElements.CAPABILITY:
         aas_types.Capability,
 
-    aas_types.AASSubmodelElements.DATA_ELEMENT:
+    aas_types.AasSubmodelElements.DATA_ELEMENT:
         aas_types.DataElement,
 
-    aas_types.AASSubmodelElements.ENTITY:
+    aas_types.AasSubmodelElements.ENTITY:
         aas_types.Entity,
 
-    aas_types.AASSubmodelElements.EVENT_ELEMENT:
+    aas_types.AasSubmodelElements.EVENT_ELEMENT:
         aas_types.EventElement,
 
-    aas_types.AASSubmodelElements.FILE:
+    aas_types.AasSubmodelElements.FILE:
         aas_types.File,
 
-    aas_types.AASSubmodelElements.MULTI_LANGUAGE_PROPERTY:
+    aas_types.AasSubmodelElements.MULTI_LANGUAGE_PROPERTY:
         aas_types.MultiLanguageProperty,
 
-    aas_types.AASSubmodelElements.OPERATION:
+    aas_types.AasSubmodelElements.OPERATION:
         aas_types.Operation,
 
-    aas_types.AASSubmodelElements.PROPERTY:
+    aas_types.AasSubmodelElements.PROPERTY:
         aas_types.Property,
 
-    aas_types.AASSubmodelElements.RANGE:
+    aas_types.AasSubmodelElements.RANGE:
         aas_types.Range,
 
-    aas_types.AASSubmodelElements.REFERENCE_ELEMENT:
+    aas_types.AasSubmodelElements.REFERENCE_ELEMENT:
         aas_types.ReferenceElement,
 
-    aas_types.AASSubmodelElements.RELATIONSHIP_ELEMENT:
+    aas_types.AasSubmodelElements.RELATIONSHIP_ELEMENT:
         aas_types.RelationshipElement,
 
-    aas_types.AASSubmodelElements.SUBMODEL_ELEMENT:
+    aas_types.AasSubmodelElements.SUBMODEL_ELEMENT:
         aas_types.SubmodelElement,
 
-    aas_types.AASSubmodelElements.SUBMODEL_ELEMENT_LIST:
+    aas_types.AasSubmodelElements.SUBMODEL_ELEMENT_LIST:
         aas_types.SubmodelElementList,
 
-    aas_types.AASSubmodelElements.SUBMODEL_ELEMENT_COLLECTION:
+    aas_types.AasSubmodelElements.SUBMODEL_ELEMENT_COLLECTION:
         aas_types.SubmodelElementCollection,
 }
 # fmt: on
@@ -1724,7 +1724,7 @@ def _assert_all_types_covered_in_aas_submodel_elements_to_type() -> None:
     """
     missing_literals = [
         literal
-        for literal in aas_types.AASSubmodelElements
+        for literal in aas_types.AasSubmodelElements
         if literal not in _AAS_SUBMODEL_ELEMENTS_TO_TYPE
     ]
 
@@ -1738,7 +1738,7 @@ _assert_all_types_covered_in_aas_submodel_elements_to_type()
 
 
 def submodel_element_is_of_type(
-    element: aas_types.SubmodelElement, expected_type: aas_types.AASSubmodelElements
+    element: aas_types.SubmodelElement, expected_type: aas_types.AasSubmodelElements
 ) -> bool:
     """
     Check that :paramref:`element` is an instance of class corresponding
@@ -1749,7 +1749,7 @@ def submodel_element_is_of_type(
 
 
 def properties_or_ranges_have_value_type(
-    elements: Iterable[aas_types.SubmodelElement], value_type: aas_types.DataTypeDefXSD
+    elements: Iterable[aas_types.SubmodelElement], value_type: aas_types.DataTypeDefXsd
 ) -> bool:
     """
     Check that :paramref:`elements` which are
@@ -2851,9 +2851,9 @@ class _Transformer(aas_types.AbstractTransformer[Iterator[Error]]):
                     and (
                         (
                             that.type_value_list_element
-                            == aas_types.AASSubmodelElements.PROPERTY
+                            == aas_types.AasSubmodelElements.PROPERTY
                             or that.type_value_list_element
-                            == aas_types.AASSubmodelElements.RANGE
+                            == aas_types.AasSubmodelElements.RANGE
                         )
                     )
                 )

--- a/aas_core3_rc02/xmlization.py
+++ b/aas_core3_rc02/xmlization.py
@@ -8679,7 +8679,7 @@ class _ReaderAndSetterForExtension:
         self.semantic_id: Optional[aas_types.Reference] = None
         self.supplemental_semantic_ids: Optional[List[aas_types.Reference]] = None
         self.name: Optional[str] = None
-        self.value_type: Optional[aas_types.DataTypeDefXSD] = None
+        self.value_type: Optional[aas_types.DataTypeDefXsd] = None
         self.value: Optional[str] = None
         self.refers_to: Optional[aas_types.Reference] = None
 
@@ -9312,7 +9312,7 @@ class _ReaderAndSetterForQualifier:
         self.supplemental_semantic_ids: Optional[List[aas_types.Reference]] = None
         self.kind: Optional[aas_types.QualifierKind] = None
         self.type: Optional[str] = None
-        self.value_type: Optional[aas_types.DataTypeDefXSD] = None
+        self.value_type: Optional[aas_types.DataTypeDefXsd] = None
         self.value: Optional[str] = None
         self.value_id: Optional[aas_types.Reference] = None
 
@@ -11625,10 +11625,10 @@ def _read_relationship_element_as_element(
 
 def _read_aas_submodel_elements_from_element_text(
     element: Element, iterator: Iterator[Tuple[str, Element]]
-) -> aas_types.AASSubmodelElements:
+) -> aas_types.AasSubmodelElements:
     """
     Parse the text of :paramref:`element` as a literal of
-    :py:class:`.types.AASSubmodelElements`, and read the corresponding
+    :py:class:`.types.AasSubmodelElements`, and read the corresponding
     end element from :paramref:`iterator`.
 
     :param element: start element
@@ -11645,7 +11645,7 @@ def _read_aas_submodel_elements_from_element_text(
     if literal is None:
         raise DeserializationException(
             f"Not a valid string representation of "
-            f"a literal of AASSubmodelElements: {text}"
+            f"a literal of AasSubmodelElements: {text}"
         )
 
     return literal
@@ -11679,8 +11679,8 @@ class _ReaderAndSetterForSubmodelElementList:
         self.order_relevant: Optional[bool] = None
         self.value: Optional[List[aas_types.SubmodelElement]] = None
         self.semantic_id_list_element: Optional[aas_types.Reference] = None
-        self.type_value_list_element: Optional[aas_types.AASSubmodelElements] = None
-        self.value_type_list_element: Optional[aas_types.DataTypeDefXSD] = None
+        self.type_value_list_element: Optional[aas_types.AasSubmodelElements] = None
+        self.value_type_list_element: Optional[aas_types.DataTypeDefXsd] = None
 
     def read_and_set_extensions(
         self, element: Element, iterator: Iterator[Tuple[str, Element]]
@@ -12789,7 +12789,7 @@ class _ReaderAndSetterForProperty:
         self.embedded_data_specifications: Optional[
             List[aas_types.EmbeddedDataSpecification]
         ] = None
-        self.value_type: Optional[aas_types.DataTypeDefXSD] = None
+        self.value_type: Optional[aas_types.DataTypeDefXsd] = None
         self.value: Optional[str] = None
         self.value_id: Optional[aas_types.Reference] = None
 
@@ -13817,7 +13817,7 @@ class _ReaderAndSetterForRange:
         self.embedded_data_specifications: Optional[
             List[aas_types.EmbeddedDataSpecification]
         ] = None
-        self.value_type: Optional[aas_types.DataTypeDefXSD] = None
+        self.value_type: Optional[aas_types.DataTypeDefXsd] = None
         self.min: Optional[str] = None
         self.max: Optional[str] = None
 
@@ -19761,10 +19761,10 @@ def _read_key_types_from_element_text(
 
 def _read_data_type_def_xsd_from_element_text(
     element: Element, iterator: Iterator[Tuple[str, Element]]
-) -> aas_types.DataTypeDefXSD:
+) -> aas_types.DataTypeDefXsd:
     """
     Parse the text of :paramref:`element` as a literal of
-    :py:class:`.types.DataTypeDefXSD`, and read the corresponding
+    :py:class:`.types.DataTypeDefXsd`, and read the corresponding
     end element from :paramref:`iterator`.
 
     :param element: start element
@@ -19781,7 +19781,7 @@ def _read_data_type_def_xsd_from_element_text(
     if literal is None:
         raise DeserializationException(
             f"Not a valid string representation of "
-            f"a literal of DataTypeDefXSD: {text}"
+            f"a literal of DataTypeDefXsd: {text}"
         )
 
     return literal

--- a/docs/source/getting_started/create_get_set.rst
+++ b/docs/source/getting_started/create_get_set.rst
@@ -44,7 +44,7 @@ The submodel will contain two elements, a property and a blob.
     # Create the first element
     some_element = aas_types.Property(
         id_short="some_property",
-        value_type=aas_types.DataTypeDefXSD.INT,
+        value_type=aas_types.DataTypeDefXsd.INT,
         value="1984"
     )
 

--- a/docs/source/getting_started/iterate_and_transform.rst
+++ b/docs/source/getting_started/iterate_and_transform.rst
@@ -41,17 +41,17 @@ Here is a short example how you can get all the properties from an environment w
                 submodel_elements=[
                     aas_types.Property(
                         id_short="some_property",
-                        value_type=aas_types.DataTypeDefXSD.INT,
+                        value_type=aas_types.DataTypeDefXsd.INT,
                         value="1984"
                     ),
                     aas_types.Property(
                         id_short="another_property",
-                        value_type=aas_types.DataTypeDefXSD.INT,
+                        value_type=aas_types.DataTypeDefXsd.INT,
                         value="1985"
                     ),
                     aas_types.Property(
                         id_short="yet_another_property",
-                        value_type=aas_types.DataTypeDefXSD.INT,
+                        value_type=aas_types.DataTypeDefXsd.INT,
                         value="1986"
                     )
                 ]
@@ -121,17 +121,17 @@ Let us re-write the above example related to :py:meth:`~aas_core3_rc02.types.Cla
                 submodel_elements=[
                     aas_types.Property(
                         id_short="some_property",
-                        value_type=aas_types.DataTypeDefXSD.INT,
+                        value_type=aas_types.DataTypeDefXsd.INT,
                         value="1984"
                     ),
                     aas_types.Property(
                         id_short="another_property",
-                        value_type=aas_types.DataTypeDefXSD.INT,
+                        value_type=aas_types.DataTypeDefXsd.INT,
                         value="1985"
                     ),
                     aas_types.Property(
                         id_short="yet_another_property",
-                        value_type=aas_types.DataTypeDefXSD.INT,
+                        value_type=aas_types.DataTypeDefXsd.INT,
                         value="1986"
                     )
                 ]

--- a/docs/source/getting_started/jsonize.rst
+++ b/docs/source/getting_started/jsonize.rst
@@ -26,7 +26,7 @@ Here is a snippet that converts the environment first into a JSON-able mapping, 
                 submodel_elements=[
                     aas_types.Property(
                         id_short = "some_property",
-                        value_type=aas_types.DataTypeDefXSD.INT,
+                        value_type=aas_types.DataTypeDefXsd.INT,
                         value="1984"
                     )
                 ]

--- a/docs/source/getting_started/verify.rst
+++ b/docs/source/getting_started/verify.rst
@@ -25,7 +25,7 @@ Here is a short example snippet:
                         # The ID-shorts must be proper variable names,
                         # but there is a dash ("-") in this ID-short.
                         id_short = "some-Property",
-                        value_type=aas_types.DataTypeDefXSD.INT,
+                        value_type=aas_types.DataTypeDefXsd.INT,
                         value="1984"
                     )
                 ]

--- a/docs/source/getting_started/xmlize.rst
+++ b/docs/source/getting_started/xmlize.rst
@@ -26,7 +26,7 @@ Here is an example snippet:
                 submodel_elements=[
                     aas_types.Property(
                         id_short = "some_property",
-                        value_type=aas_types.DataTypeDefXSD.INT,
+                        value_type=aas_types.DataTypeDefXsd.INT,
                         value="1984"
                     )
                 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,5 +4,5 @@ pylint==2.15.4
 coverage>=6.5.0,<7
 pyinstaller>=5<6
 twine
-aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@a8e6621#egg=aas-core-meta
-aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@46ddb38f#egg=aas-core-codegen
+aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@d180dbb#egg=aas-core-meta
+aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@44945c18#egg=aas-core-codegen

--- a/test_data/Json/ContainedInEnvironment/Unexpected/EnumViolation/Extension/valueType_as_DataTypeDefXsd.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/EnumViolation/Extension/valueType_as_DataTypeDefXsd.json.exception
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].extensions[0].valueType: Not a valid string representation of a literal of DataTypeDefXSD: invalid-literal
+assetAdministrationShells[0].extensions[0].valueType: Not a valid string representation of a literal of DataTypeDefXsd: invalid-literal

--- a/test_data/Json/ContainedInEnvironment/Unexpected/EnumViolation/Property/valueType_as_DataTypeDefXsd.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/EnumViolation/Property/valueType_as_DataTypeDefXsd.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].valueType: Not a valid string representation of a literal of DataTypeDefXSD: invalid-literal
+submodels[0].submodelElements[0].valueType: Not a valid string representation of a literal of DataTypeDefXsd: invalid-literal

--- a/test_data/Json/ContainedInEnvironment/Unexpected/EnumViolation/Qualifier/valueType_as_DataTypeDefXsd.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/EnumViolation/Qualifier/valueType_as_DataTypeDefXsd.json.exception
@@ -1,1 +1,1 @@
-submodels[0].qualifiers[0].valueType: Not a valid string representation of a literal of DataTypeDefXSD: invalid-literal
+submodels[0].qualifiers[0].valueType: Not a valid string representation of a literal of DataTypeDefXsd: invalid-literal

--- a/test_data/Json/ContainedInEnvironment/Unexpected/EnumViolation/Range/valueType_as_DataTypeDefXsd.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/EnumViolation/Range/valueType_as_DataTypeDefXsd.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].valueType: Not a valid string representation of a literal of DataTypeDefXSD: invalid-literal
+submodels[0].submodelElements[0].valueType: Not a valid string representation of a literal of DataTypeDefXsd: invalid-literal

--- a/test_data/Json/ContainedInEnvironment/Unexpected/EnumViolation/SubmodelElementList/typeValueListElement_as_AasSubmodelElements.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/EnumViolation/SubmodelElementList/typeValueListElement_as_AasSubmodelElements.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].typeValueListElement: Not a valid string representation of a literal of AASSubmodelElements: invalid-literal
+submodels[0].submodelElements[0].typeValueListElement: Not a valid string representation of a literal of AasSubmodelElements: invalid-literal

--- a/test_data/Json/ContainedInEnvironment/Unexpected/EnumViolation/SubmodelElementList/valueTypeListElement_as_DataTypeDefXsd.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/EnumViolation/SubmodelElementList/valueTypeListElement_as_DataTypeDefXsd.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].valueTypeListElement: Not a valid string representation of a literal of DataTypeDefXSD: invalid-literal
+submodels[0].submodelElements[0].valueTypeListElement: Not a valid string representation of a literal of DataTypeDefXsd: invalid-literal

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Extension/valueType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Extension/valueType.json.exception
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].extensions[0].valueType: Not a valid string representation of a literal of DataTypeDefXSD: Unexpected string value
+assetAdministrationShells[0].extensions[0].valueType: Not a valid string representation of a literal of DataTypeDefXsd: Unexpected string value

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/valueType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/valueType.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].valueType: Not a valid string representation of a literal of DataTypeDefXSD: Unexpected string value
+submodels[0].submodelElements[0].valueType: Not a valid string representation of a literal of DataTypeDefXsd: Unexpected string value

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/valueType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/valueType.json.exception
@@ -1,1 +1,1 @@
-submodels[0].qualifiers[0].valueType: Not a valid string representation of a literal of DataTypeDefXSD: Unexpected string value
+submodels[0].qualifiers[0].valueType: Not a valid string representation of a literal of DataTypeDefXsd: Unexpected string value

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/valueType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/valueType.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].valueType: Not a valid string representation of a literal of DataTypeDefXSD: Unexpected string value
+submodels[0].submodelElements[0].valueType: Not a valid string representation of a literal of DataTypeDefXsd: Unexpected string value

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/typeValueListElement.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/typeValueListElement.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].typeValueListElement: Not a valid string representation of a literal of AASSubmodelElements: Unexpected string value
+submodels[0].submodelElements[0].typeValueListElement: Not a valid string representation of a literal of AasSubmodelElements: Unexpected string value

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/valueTypeListElement.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/valueTypeListElement.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].valueTypeListElement: Not a valid string representation of a literal of DataTypeDefXSD: Unexpected string value
+submodels[0].submodelElements[0].valueTypeListElement: Not a valid string representation of a literal of DataTypeDefXsd: Unexpected string value

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/extension/valueType_as_dataTypeDefXsd.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/extension/valueType_as_dataTypeDefXsd.xml.exception
@@ -1,1 +1,1 @@
-environment/assetAdministrationShells/*[0]/extensions/*[0]/valueType: Not a valid string representation of a literal of DataTypeDefXSD: invalid-literal
+environment/assetAdministrationShells/*[0]/extensions/*[0]/valueType: Not a valid string representation of a literal of DataTypeDefXsd: invalid-literal

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/property/valueType_as_dataTypeDefXsd.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/property/valueType_as_dataTypeDefXsd.xml.exception
@@ -1,1 +1,1 @@
-environment/submodels/*[0]/submodelElements/*[0]/valueType: Not a valid string representation of a literal of DataTypeDefXSD: invalid-literal
+environment/submodels/*[0]/submodelElements/*[0]/valueType: Not a valid string representation of a literal of DataTypeDefXsd: invalid-literal

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/qualifier/valueType_as_dataTypeDefXsd.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/qualifier/valueType_as_dataTypeDefXsd.xml.exception
@@ -1,1 +1,1 @@
-environment/submodels/*[0]/qualifiers/*[0]/valueType: Not a valid string representation of a literal of DataTypeDefXSD: invalid-literal
+environment/submodels/*[0]/qualifiers/*[0]/valueType: Not a valid string representation of a literal of DataTypeDefXsd: invalid-literal

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/range/valueType_as_dataTypeDefXsd.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/range/valueType_as_dataTypeDefXsd.xml.exception
@@ -1,1 +1,1 @@
-environment/submodels/*[0]/submodelElements/*[0]/valueType: Not a valid string representation of a literal of DataTypeDefXSD: invalid-literal
+environment/submodels/*[0]/submodelElements/*[0]/valueType: Not a valid string representation of a literal of DataTypeDefXsd: invalid-literal

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/submodelElementList/typeValueListElement_as_aasSubmodelElements.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/submodelElementList/typeValueListElement_as_aasSubmodelElements.xml.exception
@@ -1,1 +1,1 @@
-environment/submodels/*[0]/submodelElements/*[0]/typeValueListElement: Not a valid string representation of a literal of AASSubmodelElements: invalid-literal
+environment/submodels/*[0]/submodelElements/*[0]/typeValueListElement: Not a valid string representation of a literal of AasSubmodelElements: invalid-literal

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/submodelElementList/valueTypeListElement_as_dataTypeDefXsd.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/EnumViolation/submodelElementList/valueTypeListElement_as_dataTypeDefXsd.xml.exception
@@ -1,1 +1,1 @@
-environment/submodels/*[0]/submodelElements/*[0]/valueTypeListElement: Not a valid string representation of a literal of DataTypeDefXSD: invalid-literal
+environment/submodels/*[0]/submodelElements/*[0]/valueTypeListElement: Not a valid string representation of a literal of DataTypeDefXsd: invalid-literal

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/extension/valueType.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/extension/valueType.xml.exception
@@ -1,1 +1,1 @@
-environment/assetAdministrationShells/*[0]/extensions/*[0]/valueType: Not a valid string representation of a literal of DataTypeDefXSD: Unexpected string value
+environment/assetAdministrationShells/*[0]/extensions/*[0]/valueType: Not a valid string representation of a literal of DataTypeDefXsd: Unexpected string value

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/valueType.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/property/valueType.xml.exception
@@ -1,1 +1,1 @@
-environment/submodels/*[0]/submodelElements/*[0]/valueType: Not a valid string representation of a literal of DataTypeDefXSD: Unexpected string value
+environment/submodels/*[0]/submodelElements/*[0]/valueType: Not a valid string representation of a literal of DataTypeDefXsd: Unexpected string value

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/valueType.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/qualifier/valueType.xml.exception
@@ -1,1 +1,1 @@
-environment/submodels/*[0]/qualifiers/*[0]/valueType: Not a valid string representation of a literal of DataTypeDefXSD: Unexpected string value
+environment/submodels/*[0]/qualifiers/*[0]/valueType: Not a valid string representation of a literal of DataTypeDefXsd: Unexpected string value

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/valueType.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/range/valueType.xml.exception
@@ -1,1 +1,1 @@
-environment/submodels/*[0]/submodelElements/*[0]/valueType: Not a valid string representation of a literal of DataTypeDefXSD: Unexpected string value
+environment/submodels/*[0]/submodelElements/*[0]/valueType: Not a valid string representation of a literal of DataTypeDefXsd: Unexpected string value

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/typeValueListElement.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/typeValueListElement.xml.exception
@@ -1,1 +1,1 @@
-environment/submodels/*[0]/submodelElements/*[0]/typeValueListElement: Not a valid string representation of a literal of AASSubmodelElements: Unexpected string value
+environment/submodels/*[0]/submodelElements/*[0]/typeValueListElement: Not a valid string representation of a literal of AasSubmodelElements: Unexpected string value

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/valueTypeListElement.xml.exception
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/TypeViolation/submodelElementList/valueTypeListElement.xml.exception
@@ -1,1 +1,1 @@
-environment/submodels/*[0]/submodelElements/*[0]/valueTypeListElement: Not a valid string representation of a literal of DataTypeDefXSD: Unexpected string value
+environment/submodels/*[0]/submodelElements/*[0]/valueTypeListElement: Not a valid string representation of a literal of DataTypeDefXsd: Unexpected string value

--- a/test_data/test_X_or_default/Extension/on_complete.json/value_type_or_default.trace
+++ b/test_data/test_X_or_default/Extension/on_complete.json/value_type_or_default.trace
@@ -1,2 +1,2 @@
-DataTypeDefXSD.BOOLEAN
+DataTypeDefXsd.BOOLEAN
 

--- a/test_data/test_X_or_default/Extension/on_minimal.json/value_type_or_default.trace
+++ b/test_data/test_X_or_default/Extension/on_minimal.json/value_type_or_default.trace
@@ -1,2 +1,2 @@
-DataTypeDefXSD.BOOLEAN
+DataTypeDefXsd.BOOLEAN
 

--- a/tests/test_jsonization_of_enums.py
+++ b/tests/test_jsonization_of_enums.py
@@ -41,7 +41,7 @@ class Test_AssetKind(unittest.TestCase):
         self.assertEqual(enum_literal.value, jsonable)
 
 
-class Test_AASSubmodelElements(unittest.TestCase):
+class Test_AasSubmodelElements(unittest.TestCase):
     def test_round_trip(self) -> None:
         jsonable = "AnnotatedRelationshipElement"
 
@@ -95,7 +95,7 @@ class Test_KeyTypes(unittest.TestCase):
         self.assertEqual(enum_literal.value, jsonable)
 
 
-class Test_DataTypeDefXSD(unittest.TestCase):
+class Test_DataTypeDefXsd(unittest.TestCase):
     def test_round_trip(self) -> None:
         jsonable = "xs:anyURI"
 


### PR DESCRIPTION
Unfortunately, we had a bug in [aas-core-codegen e2a7a806] (2022-10-30) and prior versions where we generated the names for JSON and RDF schemas based on a hard-wired list of abbreviations in *aas-core-codegen* instead of relying on the naming in aas-core-meta. This list has not been updated before publishing the schemas, so we have to stick with the unexpected casing in the names. To maintain the compatibility with the schemas, we allow for capitalization of certain abbreviations where uppercase would be expected. Concretely, this was the case with abbreviations "AAS" and "XSD".

In this patch, we rename the class names to match the published schemas although the names are not pythonic (``AasSubmodelElements`` instead of ``AASSubmodelElements``). While this is ugly, it gives us backwards compatibility in the future versions of aas-core-meta and aas-core-codegen when it comes to generating Python code.

This code has been generated using:
* [aas-core-meta d180dbb] and
* [aas-core-codegen 44945c18].

[aas-core-codegen e2a7a806]: https://github.com/aas-core-works/aas-core-codegen/commit/e2a7a806
[aas-core-codegen 44945c18]: https://github.com/aas-core-works/aas-core-codegen/commit/44945c18
[aas-core-meta d180dbb]: https://github.com/aas-core-works/aas-core-meta/commit/d180dbb