### PR TITLE
Test validation of dates for zero and BCE years

### DIFF
--- a/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date/year_1_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date/year_1_bce_is_a_leap_year.json
@@ -1,0 +1,18 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        {
+          "name": "something_random_8ddedf5d",
+          "value": "-0001-02-29",
+          "valueType": "xs:date"
+        }
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date/year_5_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date/year_5_bce_is_a_leap_year.json
@@ -1,0 +1,18 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        {
+          "name": "something_random_8ddedf5d",
+          "value": "-0005-02-29",
+          "valueType": "xs:date"
+        }
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.json
@@ -1,0 +1,18 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        {
+          "name": "something_random_8ddedf5d",
+          "value": "-0001-02-29T01:02:03",
+          "valueType": "xs:dateTime"
+        }
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.json
@@ -1,0 +1,18 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        {
+          "name": "something_random_8ddedf5d",
+          "value": "-0005-02-29T01:02:03",
+          "valueType": "xs:dateTime"
+        }
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.json
@@ -1,0 +1,18 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        {
+          "name": "something_random_8ddedf5d",
+          "value": "-0001-02-29T01:02:03Z",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.json
@@ -1,0 +1,18 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        {
+          "name": "something_random_8ddedf5d",
+          "value": "-0005-02-29T01:02:03Z",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date/year_1_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date/year_1_bce_is_a_leap_year.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "Property",
+          "value": "-0001-02-29",
+          "valueType": "xs:date"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date/year_5_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date/year_5_bce_is_a_leap_year.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "Property",
+          "value": "-0005-02-29",
+          "valueType": "xs:date"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "Property",
+          "value": "-0001-02-29T01:02:03",
+          "valueType": "xs:dateTime"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "Property",
+          "value": "-0005-02-29T01:02:03",
+          "valueType": "xs:dateTime"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "Property",
+          "value": "-0001-02-29T01:02:03Z",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "Property",
+          "value": "-0005-02-29T01:02:03Z",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date/year_1_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date/year_1_bce_is_a_leap_year.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "type": "something_random_cfd39ba4",
+          "value": "-0001-02-29",
+          "valueType": "xs:date"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date/year_5_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date/year_5_bce_is_a_leap_year.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "type": "something_random_cfd39ba4",
+          "value": "-0005-02-29",
+          "valueType": "xs:date"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "type": "something_random_cfd39ba4",
+          "value": "-0001-02-29T01:02:03",
+          "valueType": "xs:dateTime"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "type": "something_random_cfd39ba4",
+          "value": "-0005-02-29T01:02:03",
+          "valueType": "xs:dateTime"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "type": "something_random_cfd39ba4",
+          "value": "-0001-02-29T01:02:03Z",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "type": "something_random_cfd39ba4",
+          "value": "-0005-02-29T01:02:03Z",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date/year_1_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date/year_1_bce_is_a_leap_year.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "max": "-0001-02-29",
+          "min": "-0001-02-29",
+          "modelType": "Range",
+          "valueType": "xs:date"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date/year_5_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date/year_5_bce_is_a_leap_year.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "max": "-0005-02-29",
+          "min": "-0005-02-29",
+          "modelType": "Range",
+          "valueType": "xs:date"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date_time/year_1_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date_time/year_1_bce_is_a_leap_year.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "max": "-0001-02-29T01:02:03",
+          "min": "-0001-02-29T01:02:03",
+          "modelType": "Range",
+          "valueType": "xs:dateTime"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date_time/year_5_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date_time/year_5_bce_is_a_leap_year.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "max": "-0005-02-29T01:02:03",
+          "min": "-0005-02-29T01:02:03",
+          "modelType": "Range",
+          "valueType": "xs:dateTime"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date_time_stamp/year_1_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date_time_stamp/year_1_bce_is_a_leap_year.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "max": "-0001-02-29T01:02:03Z",
+          "min": "-0001-02-29T01:02:03Z",
+          "modelType": "Range",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date_time_stamp/year_5_bce_is_a_leap_year.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date_time_stamp/year_5_bce_is_a_leap_year.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "max": "-0005-02-29T01:02:03Z",
+          "min": "-0005-02-29T01:02:03Z",
+          "modelType": "Range",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/year_4_bce_february_29th.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/year_4_bce_february_29th.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "max": "-0004-02-29",
+          "min": "-0004-02-29",
+          "modelType": "Range",
+          "valueType": "xs:date"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/year_4_bce_february_29th.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/year_4_bce_february_29th.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/year_zero_doesnt_exist.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/year_zero_doesnt_exist.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "max": "0000-01-02",
+          "min": "0000-01-02",
+          "modelType": "Range",
+          "valueType": "xs:date"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/year_zero_doesnt_exist.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date/year_zero_doesnt_exist.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/year_4_bce_february_29th.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/year_4_bce_february_29th.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "max": "-0004-02-29T01:02:03",
+          "min": "-0004-02-29T01:02:03",
+          "modelType": "Range",
+          "valueType": "xs:dateTime"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/year_4_bce_february_29th.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/year_4_bce_february_29th.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/year_zero_doesnt_exist.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/year_zero_doesnt_exist.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "max": "0000-01-02T01:02:03",
+          "min": "0000-01-02T01:02:03",
+          "modelType": "Range",
+          "valueType": "xs:dateTime"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/year_zero_doesnt_exist.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time/year_zero_doesnt_exist.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/year_4_bce_february_29th.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/year_4_bce_february_29th.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "max": "-0004-02-29T01:02:03Z",
+          "min": "-0004-02-29T01:02:03Z",
+          "modelType": "Range",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/year_4_bce_february_29th.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/year_4_bce_february_29th.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/year_zero_doesnt_exist.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/year_zero_doesnt_exist.json
@@ -1,0 +1,17 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "max": "0000-01-02T01:02:03Z",
+          "min": "0000-01-02T01:02:03Z",
+          "modelType": "Range",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/year_zero_doesnt_exist.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/Range/Date_time_stamp/year_zero_doesnt_exist.json.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/year_4_bce_february_29th.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/year_4_bce_february_29th.json
@@ -1,0 +1,18 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        {
+          "name": "something_random_8ddedf5d",
+          "value": "-0004-02-29",
+          "valueType": "xs:date"
+        }
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/year_4_bce_february_29th.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/year_4_bce_february_29th.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/year_zero_doesnt_exist.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/year_zero_doesnt_exist.json
@@ -1,0 +1,18 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        {
+          "name": "something_random_8ddedf5d",
+          "value": "0000-01-02",
+          "valueType": "xs:date"
+        }
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/year_zero_doesnt_exist.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date/year_zero_doesnt_exist.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/year_4_bce_february_29th.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/year_4_bce_february_29th.json
@@ -1,0 +1,18 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        {
+          "name": "something_random_8ddedf5d",
+          "value": "-0004-02-29T01:02:03",
+          "valueType": "xs:dateTime"
+        }
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/year_4_bce_february_29th.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/year_4_bce_february_29th.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/year_zero_doesnt_exist.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/year_zero_doesnt_exist.json
@@ -1,0 +1,18 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        {
+          "name": "something_random_8ddedf5d",
+          "value": "0000-01-02T01:02:03",
+          "valueType": "xs:dateTime"
+        }
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/year_zero_doesnt_exist.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time/year_zero_doesnt_exist.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/year_4_bce_february_29th.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/year_4_bce_february_29th.json
@@ -1,0 +1,18 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        {
+          "name": "something_random_8ddedf5d",
+          "value": "-0004-02-29T01:02:03Z",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/year_4_bce_february_29th.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/year_4_bce_february_29th.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/year_zero_doesnt_exist.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/year_zero_doesnt_exist.json
@@ -1,0 +1,18 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "Instance"
+      },
+      "extensions": [
+        {
+          "name": "something_random_8ddedf5d",
+          "value": "0000-01-02T01:02:03Z",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ],
+      "id": "something_random_428f0205",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/year_zero_doesnt_exist.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Extension/Date_time_stamp/year_zero_doesnt_exist.json.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/year_4_bce_february_29th.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/year_4_bce_february_29th.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "Property",
+          "value": "-0004-02-29",
+          "valueType": "xs:date"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/year_4_bce_february_29th.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/year_4_bce_february_29th.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/year_zero_doesnt_exist.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/year_zero_doesnt_exist.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "Property",
+          "value": "0000-01-02",
+          "valueType": "xs:date"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/year_zero_doesnt_exist.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date/year_zero_doesnt_exist.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/year_4_bce_february_29th.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/year_4_bce_february_29th.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "Property",
+          "value": "-0004-02-29T01:02:03",
+          "valueType": "xs:dateTime"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/year_4_bce_february_29th.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/year_4_bce_february_29th.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/year_zero_doesnt_exist.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/year_zero_doesnt_exist.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "Property",
+          "value": "0000-01-02T01:02:03",
+          "valueType": "xs:dateTime"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/year_zero_doesnt_exist.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time/year_zero_doesnt_exist.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/year_4_bce_february_29th.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/year_4_bce_february_29th.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "Property",
+          "value": "-0004-02-29T01:02:03Z",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/year_4_bce_february_29th.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/year_4_bce_february_29th.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/year_zero_doesnt_exist.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/year_zero_doesnt_exist.json
@@ -1,0 +1,16 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "some_id_short_10b21b1b",
+          "modelType": "Property",
+          "value": "0000-01-02T01:02:03Z",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/year_zero_doesnt_exist.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Property/Date_time_stamp/year_zero_doesnt_exist.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/year_4_bce_february_29th.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/year_4_bce_february_29th.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "type": "something_random_cfd39ba4",
+          "value": "-0004-02-29",
+          "valueType": "xs:date"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/year_4_bce_february_29th.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/year_4_bce_february_29th.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/year_zero_doesnt_exist.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/year_zero_doesnt_exist.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "type": "something_random_cfd39ba4",
+          "value": "0000-01-02",
+          "valueType": "xs:date"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/year_zero_doesnt_exist.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date/year_zero_doesnt_exist.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/year_4_bce_february_29th.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/year_4_bce_february_29th.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "type": "something_random_cfd39ba4",
+          "value": "-0004-02-29T01:02:03",
+          "valueType": "xs:dateTime"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/year_4_bce_february_29th.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/year_4_bce_february_29th.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/year_zero_doesnt_exist.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/year_zero_doesnt_exist.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "type": "something_random_cfd39ba4",
+          "value": "0000-01-02T01:02:03",
+          "valueType": "xs:dateTime"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/year_zero_doesnt_exist.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time/year_zero_doesnt_exist.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/year_4_bce_february_29th.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/year_4_bce_february_29th.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "type": "something_random_cfd39ba4",
+          "value": "-0004-02-29T01:02:03Z",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/year_4_bce_february_29th.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/year_4_bce_february_29th.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/year_zero_doesnt_exist.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/year_zero_doesnt_exist.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_random_b0c234ba",
+      "modelType": "Submodel",
+      "qualifiers": [
+        {
+          "type": "something_random_cfd39ba4",
+          "value": "0000-01-02T01:02:03Z",
+          "valueType": "xs:dateTimeStamp"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/year_zero_doesnt_exist.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/InvalidValueExample/Qualifier/Date_time_stamp/year_zero_doesnt_exist.json.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date/year_1_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date/year_1_bce_is_a_leap_year.xml
@@ -1,0 +1,17 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>
+		<assetAdministrationShell>
+			<extensions>
+				<extension>
+					<name>something_random_8ddedf5d</name>
+					<valueType>xs:date</valueType>
+					<value>-0001-02-29</value>
+				</extension>
+			</extensions>
+			<id>something_random_428f0205</id>
+			<assetInformation>
+				<assetKind>Instance</assetKind>
+			</assetInformation>
+		</assetAdministrationShell>
+	</assetAdministrationShells>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date/year_5_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date/year_5_bce_is_a_leap_year.xml
@@ -1,0 +1,17 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>
+		<assetAdministrationShell>
+			<extensions>
+				<extension>
+					<name>something_random_8ddedf5d</name>
+					<valueType>xs:date</valueType>
+					<value>-0005-02-29</value>
+				</extension>
+			</extensions>
+			<id>something_random_428f0205</id>
+			<assetInformation>
+				<assetKind>Instance</assetKind>
+			</assetInformation>
+		</assetAdministrationShell>
+	</assetAdministrationShells>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.xml
@@ -1,0 +1,17 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>
+		<assetAdministrationShell>
+			<extensions>
+				<extension>
+					<name>something_random_8ddedf5d</name>
+					<valueType>xs:dateTime</valueType>
+					<value>-0001-02-29T01:02:03</value>
+				</extension>
+			</extensions>
+			<id>something_random_428f0205</id>
+			<assetInformation>
+				<assetKind>Instance</assetKind>
+			</assetInformation>
+		</assetAdministrationShell>
+	</assetAdministrationShells>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.xml
@@ -1,0 +1,17 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>
+		<assetAdministrationShell>
+			<extensions>
+				<extension>
+					<name>something_random_8ddedf5d</name>
+					<valueType>xs:dateTime</valueType>
+					<value>-0005-02-29T01:02:03</value>
+				</extension>
+			</extensions>
+			<id>something_random_428f0205</id>
+			<assetInformation>
+				<assetKind>Instance</assetKind>
+			</assetInformation>
+		</assetAdministrationShell>
+	</assetAdministrationShells>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.xml
@@ -1,0 +1,17 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>
+		<assetAdministrationShell>
+			<extensions>
+				<extension>
+					<name>something_random_8ddedf5d</name>
+					<valueType>xs:dateTimeStamp</valueType>
+					<value>-0001-02-29T01:02:03Z</value>
+				</extension>
+			</extensions>
+			<id>something_random_428f0205</id>
+			<assetInformation>
+				<assetKind>Instance</assetKind>
+			</assetInformation>
+		</assetAdministrationShell>
+	</assetAdministrationShells>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.xml
@@ -1,0 +1,17 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>
+		<assetAdministrationShell>
+			<extensions>
+				<extension>
+					<name>something_random_8ddedf5d</name>
+					<valueType>xs:dateTimeStamp</valueType>
+					<value>-0005-02-29T01:02:03Z</value>
+				</extension>
+			</extensions>
+			<id>something_random_428f0205</id>
+			<assetInformation>
+				<assetKind>Instance</assetKind>
+			</assetInformation>
+		</assetAdministrationShell>
+	</assetAdministrationShells>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date/year_1_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date/year_1_bce_is_a_leap_year.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<property>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:date</valueType>
+					<value>-0001-02-29</value>
+				</property>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date/year_5_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date/year_5_bce_is_a_leap_year.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<property>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:date</valueType>
+					<value>-0005-02-29</value>
+				</property>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<property>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTime</valueType>
+					<value>-0001-02-29T01:02:03</value>
+				</property>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<property>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTime</valueType>
+					<value>-0005-02-29T01:02:03</value>
+				</property>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<property>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTimeStamp</valueType>
+					<value>-0001-02-29T01:02:03Z</value>
+				</property>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<property>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTimeStamp</valueType>
+					<value>-0005-02-29T01:02:03Z</value>
+				</property>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date/year_1_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date/year_1_bce_is_a_leap_year.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<qualifiers>
+				<qualifier>
+					<type>something_random_cfd39ba4</type>
+					<valueType>xs:date</valueType>
+					<value>-0001-02-29</value>
+				</qualifier>
+			</qualifiers>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date/year_5_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date/year_5_bce_is_a_leap_year.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<qualifiers>
+				<qualifier>
+					<type>something_random_cfd39ba4</type>
+					<valueType>xs:date</valueType>
+					<value>-0005-02-29</value>
+				</qualifier>
+			</qualifiers>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date_time/year_1_bce_is_a_leap_year.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<qualifiers>
+				<qualifier>
+					<type>something_random_cfd39ba4</type>
+					<valueType>xs:dateTime</valueType>
+					<value>-0001-02-29T01:02:03</value>
+				</qualifier>
+			</qualifiers>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date_time/year_5_bce_is_a_leap_year.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<qualifiers>
+				<qualifier>
+					<type>something_random_cfd39ba4</type>
+					<valueType>xs:dateTime</valueType>
+					<value>-0005-02-29T01:02:03</value>
+				</qualifier>
+			</qualifiers>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date_time_stamp/year_1_bce_is_a_leap_year.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<qualifiers>
+				<qualifier>
+					<type>something_random_cfd39ba4</type>
+					<valueType>xs:dateTimeStamp</valueType>
+					<value>-0001-02-29T01:02:03Z</value>
+				</qualifier>
+			</qualifiers>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date_time_stamp/year_5_bce_is_a_leap_year.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<qualifiers>
+				<qualifier>
+					<type>something_random_cfd39ba4</type>
+					<valueType>xs:dateTimeStamp</valueType>
+					<value>-0005-02-29T01:02:03Z</value>
+				</qualifier>
+			</qualifiers>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date/year_1_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date/year_1_bce_is_a_leap_year.xml
@@ -1,0 +1,15 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<range>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:date</valueType>
+					<min>-0001-02-29</min>
+					<max>-0001-02-29</max>
+				</range>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date/year_5_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date/year_5_bce_is_a_leap_year.xml
@@ -1,0 +1,15 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<range>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:date</valueType>
+					<min>-0005-02-29</min>
+					<max>-0005-02-29</max>
+				</range>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date_time/year_1_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date_time/year_1_bce_is_a_leap_year.xml
@@ -1,0 +1,15 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<range>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTime</valueType>
+					<min>-0001-02-29T01:02:03</min>
+					<max>-0001-02-29T01:02:03</max>
+				</range>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date_time/year_5_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date_time/year_5_bce_is_a_leap_year.xml
@@ -1,0 +1,15 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<range>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTime</valueType>
+					<min>-0005-02-29T01:02:03</min>
+					<max>-0005-02-29T01:02:03</max>
+				</range>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date_time_stamp/year_1_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date_time_stamp/year_1_bce_is_a_leap_year.xml
@@ -1,0 +1,15 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<range>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTimeStamp</valueType>
+					<min>-0001-02-29T01:02:03Z</min>
+					<max>-0001-02-29T01:02:03Z</max>
+				</range>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date_time_stamp/year_5_bce_is_a_leap_year.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date_time_stamp/year_5_bce_is_a_leap_year.xml
@@ -1,0 +1,15 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<range>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTimeStamp</valueType>
+					<min>-0005-02-29T01:02:03Z</min>
+					<max>-0005-02-29T01:02:03Z</max>
+				</range>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date/year_4_bce_february_29th.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date/year_4_bce_february_29th.xml
@@ -1,0 +1,15 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<range>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:date</valueType>
+					<min>-0004-02-29</min>
+					<max>-0004-02-29</max>
+				</range>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date/year_4_bce_february_29th.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date/year_4_bce_february_29th.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date/year_zero_doesnt_exist.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date/year_zero_doesnt_exist.xml
@@ -1,0 +1,15 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<range>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:date</valueType>
+					<min>0000-01-02</min>
+					<max>0000-01-02</max>
+				</range>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date/year_zero_doesnt_exist.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date/year_zero_doesnt_exist.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/year_4_bce_february_29th.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/year_4_bce_february_29th.xml
@@ -1,0 +1,15 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<range>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTime</valueType>
+					<min>-0004-02-29T01:02:03</min>
+					<max>-0004-02-29T01:02:03</max>
+				</range>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/year_4_bce_february_29th.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/year_4_bce_february_29th.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/year_zero_doesnt_exist.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/year_zero_doesnt_exist.xml
@@ -1,0 +1,15 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<range>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTime</valueType>
+					<min>0000-01-02T01:02:03</min>
+					<max>0000-01-02T01:02:03</max>
+				</range>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/year_zero_doesnt_exist.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time/year_zero_doesnt_exist.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/year_4_bce_february_29th.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/year_4_bce_february_29th.xml
@@ -1,0 +1,15 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<range>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTimeStamp</valueType>
+					<min>-0004-02-29T01:02:03Z</min>
+					<max>-0004-02-29T01:02:03Z</max>
+				</range>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/year_4_bce_february_29th.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/year_4_bce_february_29th.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/year_zero_doesnt_exist.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/year_zero_doesnt_exist.xml
@@ -1,0 +1,15 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<range>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTimeStamp</valueType>
+					<min>0000-01-02T01:02:03Z</min>
+					<max>0000-01-02T01:02:03Z</max>
+				</range>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/year_zero_doesnt_exist.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidMinMaxExample/range/Date_time_stamp/year_zero_doesnt_exist.xml.errors
@@ -1,0 +1,2 @@
+.submodels[0].submodel_elements[0]: Max must be consistent with the value type.
+.submodels[0].submodel_elements[0]: Min must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date/year_4_bce_february_29th.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date/year_4_bce_february_29th.xml
@@ -1,0 +1,17 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>
+		<assetAdministrationShell>
+			<extensions>
+				<extension>
+					<name>something_random_8ddedf5d</name>
+					<valueType>xs:date</valueType>
+					<value>-0004-02-29</value>
+				</extension>
+			</extensions>
+			<id>something_random_428f0205</id>
+			<assetInformation>
+				<assetKind>Instance</assetKind>
+			</assetInformation>
+		</assetAdministrationShell>
+	</assetAdministrationShells>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date/year_4_bce_february_29th.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date/year_4_bce_february_29th.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date/year_zero_doesnt_exist.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date/year_zero_doesnt_exist.xml
@@ -1,0 +1,17 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>
+		<assetAdministrationShell>
+			<extensions>
+				<extension>
+					<name>something_random_8ddedf5d</name>
+					<valueType>xs:date</valueType>
+					<value>0000-01-02</value>
+				</extension>
+			</extensions>
+			<id>something_random_428f0205</id>
+			<assetInformation>
+				<assetKind>Instance</assetKind>
+			</assetInformation>
+		</assetAdministrationShell>
+	</assetAdministrationShells>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date/year_zero_doesnt_exist.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date/year_zero_doesnt_exist.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/year_4_bce_february_29th.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/year_4_bce_february_29th.xml
@@ -1,0 +1,17 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>
+		<assetAdministrationShell>
+			<extensions>
+				<extension>
+					<name>something_random_8ddedf5d</name>
+					<valueType>xs:dateTime</valueType>
+					<value>-0004-02-29T01:02:03</value>
+				</extension>
+			</extensions>
+			<id>something_random_428f0205</id>
+			<assetInformation>
+				<assetKind>Instance</assetKind>
+			</assetInformation>
+		</assetAdministrationShell>
+	</assetAdministrationShells>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/year_4_bce_february_29th.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/year_4_bce_february_29th.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/year_zero_doesnt_exist.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/year_zero_doesnt_exist.xml
@@ -1,0 +1,17 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>
+		<assetAdministrationShell>
+			<extensions>
+				<extension>
+					<name>something_random_8ddedf5d</name>
+					<valueType>xs:dateTime</valueType>
+					<value>0000-01-02T01:02:03</value>
+				</extension>
+			</extensions>
+			<id>something_random_428f0205</id>
+			<assetInformation>
+				<assetKind>Instance</assetKind>
+			</assetInformation>
+		</assetAdministrationShell>
+	</assetAdministrationShells>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/year_zero_doesnt_exist.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time/year_zero_doesnt_exist.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/year_4_bce_february_29th.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/year_4_bce_february_29th.xml
@@ -1,0 +1,17 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>
+		<assetAdministrationShell>
+			<extensions>
+				<extension>
+					<name>something_random_8ddedf5d</name>
+					<valueType>xs:dateTimeStamp</valueType>
+					<value>-0004-02-29T01:02:03Z</value>
+				</extension>
+			</extensions>
+			<id>something_random_428f0205</id>
+			<assetInformation>
+				<assetKind>Instance</assetKind>
+			</assetInformation>
+		</assetAdministrationShell>
+	</assetAdministrationShells>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/year_4_bce_february_29th.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/year_4_bce_february_29th.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/year_zero_doesnt_exist.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/year_zero_doesnt_exist.xml
@@ -1,0 +1,17 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<assetAdministrationShells>
+		<assetAdministrationShell>
+			<extensions>
+				<extension>
+					<name>something_random_8ddedf5d</name>
+					<valueType>xs:dateTimeStamp</valueType>
+					<value>0000-01-02T01:02:03Z</value>
+				</extension>
+			</extensions>
+			<id>something_random_428f0205</id>
+			<assetInformation>
+				<assetKind>Instance</assetKind>
+			</assetInformation>
+		</assetAdministrationShell>
+	</assetAdministrationShells>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/year_zero_doesnt_exist.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/extension/Date_time_stamp/year_zero_doesnt_exist.xml.errors
@@ -1,0 +1,1 @@
+.asset_administration_shells[0].extensions[0]: The value must match the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date/year_4_bce_february_29th.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date/year_4_bce_february_29th.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<property>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:date</valueType>
+					<value>-0004-02-29</value>
+				</property>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date/year_4_bce_february_29th.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date/year_4_bce_february_29th.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date/year_zero_doesnt_exist.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date/year_zero_doesnt_exist.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<property>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:date</valueType>
+					<value>0000-01-02</value>
+				</property>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date/year_zero_doesnt_exist.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date/year_zero_doesnt_exist.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/year_4_bce_february_29th.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/year_4_bce_february_29th.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<property>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTime</valueType>
+					<value>-0004-02-29T01:02:03</value>
+				</property>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/year_4_bce_february_29th.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/year_4_bce_february_29th.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/year_zero_doesnt_exist.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/year_zero_doesnt_exist.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<property>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTime</valueType>
+					<value>0000-01-02T01:02:03</value>
+				</property>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/year_zero_doesnt_exist.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time/year_zero_doesnt_exist.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/year_4_bce_february_29th.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/year_4_bce_february_29th.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<property>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTimeStamp</valueType>
+					<value>-0004-02-29T01:02:03Z</value>
+				</property>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/year_4_bce_february_29th.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/year_4_bce_february_29th.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/year_zero_doesnt_exist.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/year_zero_doesnt_exist.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<submodelElements>
+				<property>
+					<idShort>some_id_short_10b21b1b</idShort>
+					<valueType>xs:dateTimeStamp</valueType>
+					<value>0000-01-02T01:02:03Z</value>
+				</property>
+			</submodelElements>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/year_zero_doesnt_exist.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/property/Date_time_stamp/year_zero_doesnt_exist.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].submodel_elements[0]: Value must be consistent with the value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date/year_4_bce_february_29th.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date/year_4_bce_february_29th.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<qualifiers>
+				<qualifier>
+					<type>something_random_cfd39ba4</type>
+					<valueType>xs:date</valueType>
+					<value>-0004-02-29</value>
+				</qualifier>
+			</qualifiers>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date/year_4_bce_february_29th.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date/year_4_bce_february_29th.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date/year_zero_doesnt_exist.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date/year_zero_doesnt_exist.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<qualifiers>
+				<qualifier>
+					<type>something_random_cfd39ba4</type>
+					<valueType>xs:date</valueType>
+					<value>0000-01-02</value>
+				</qualifier>
+			</qualifiers>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date/year_zero_doesnt_exist.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date/year_zero_doesnt_exist.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/year_4_bce_february_29th.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/year_4_bce_february_29th.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<qualifiers>
+				<qualifier>
+					<type>something_random_cfd39ba4</type>
+					<valueType>xs:dateTime</valueType>
+					<value>-0004-02-29T01:02:03</value>
+				</qualifier>
+			</qualifiers>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/year_4_bce_february_29th.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/year_4_bce_february_29th.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/year_zero_doesnt_exist.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/year_zero_doesnt_exist.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<qualifiers>
+				<qualifier>
+					<type>something_random_cfd39ba4</type>
+					<valueType>xs:dateTime</valueType>
+					<value>0000-01-02T01:02:03</value>
+				</qualifier>
+			</qualifiers>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/year_zero_doesnt_exist.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time/year_zero_doesnt_exist.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/year_4_bce_february_29th.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/year_4_bce_february_29th.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<qualifiers>
+				<qualifier>
+					<type>something_random_cfd39ba4</type>
+					<valueType>xs:dateTimeStamp</valueType>
+					<value>-0004-02-29T01:02:03Z</value>
+				</qualifier>
+			</qualifiers>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/year_4_bce_february_29th.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/year_4_bce_february_29th.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/year_zero_doesnt_exist.xml
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/year_zero_doesnt_exist.xml
@@ -1,0 +1,14 @@
+<environment xmlns="https://admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>something_random_b0c234ba</id>
+			<qualifiers>
+				<qualifier>
+					<type>something_random_cfd39ba4</type>
+					<valueType>xs:dateTimeStamp</valueType>
+					<value>0000-01-02T01:02:03Z</value>
+				</qualifier>
+			</qualifiers>
+		</submodel>
+	</submodels>
+</environment>

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/year_zero_doesnt_exist.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/InvalidValueExample/qualifier/Date_time_stamp/year_zero_doesnt_exist.xml.errors
@@ -1,0 +1,1 @@
+.submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.


### PR DESCRIPTION
We test explicitly that:

* The year zero does not exist,
* The year 1 BCE is a leap year (according to [XML data types specs]),
* The year 4 BCE is *not* a leap year (which follows from the fact that year 1 BCE is a leap year!), and
* The year 5 BCE is then a leap year.

We generated the test data with [aas-core3.0rc02-testgen eeba8f71].

[XML data types specs]: https://www.w3.org/TR/xmlschema-2/#dateTime
[aas-core3.0rc02-testgen eeba8f71]: https://github.com/aas-core-works/aas-core3.0rc02-testgen/commit/eeba8f71