### PR TITLE
Remove TODO from "Getting Started"

### DIFF
--- a/docs/source/getting_started/iterate_and_transform.rst
+++ b/docs/source/getting_started/iterate_and_transform.rst
@@ -71,9 +71,6 @@ Here is a short example how you can get all the properties from an environment w
     another_property
     yet_another_property
 
-
-(You can also run the snippet at: TODO)
-
 Iteration with :py:meth:`~aas_core3_rc02.types.Class.descend_once` and :py:meth:`~aas_core3_rc02.types.Class.descend` works well if the performance is irrelevant.
 However, if the performance matters, this is not a good approach.
 First, all the children will be visited (even though you need only a small subset).


### PR DESCRIPTION
Originally, we wanted to put Python snippets from the docs on an online REPL site. It turned out that there are no good sites on which we count for long-term support. As it is fairly easy to copy/paste the snippets and run them in a Python console, we decided to leave online REPL be.