### PR TITLE
Fix minor typos in "Getting Started"

### DIFF
--- a/docs/source/getting_started/iterate_and_transform.rst
+++ b/docs/source/getting_started/iterate_and_transform.rst
@@ -84,7 +84,7 @@ Visitor
 `Visitor pattern`_ is a common design pattern in software engineering.
 We will not explain the details of the pattern here as you can read about in the ample literature in books or in Internet.
 
-The cornerstone of the visitor pattern in `double dispatch`_: instead of casting to the desired type during the iteration, the method :py:meth:`aas_core3_rc02.types.Class.accept` directly dispatches to the appropriate visitation method.
+The cornerstone of the visitor pattern is `double dispatch`_: instead of casting to the desired type during the iteration, the method :py:meth:`aas_core3_rc02.types.Class.accept` directly dispatches to the appropriate visitation method.
 
 .. _Visitor pattern: https://en.wikipedia.org/wiki/Visitor_pattern
 .. _double dispatch: https://en.wikipedia.org/wiki/Double_dispatch

--- a/docs/source/getting_started/jsonize.rst
+++ b/docs/source/getting_started/jsonize.rst
@@ -65,7 +65,7 @@ De-serialize
 ============
 
 Our SDK can convert a JSON-able mapping back to an instance of :py:class:`aas_core3_rc02.types.Environment`.
-To that end, you call the function :py:func:aas_core3_rc02.jsonization.environment_from_jsonable`.
+To that end, you call the function :py:func:`aas_core3_rc02.jsonization.environment_from_jsonable`.
 
 
 Here is an example snippet:

--- a/docs/source/getting_started/verify.rst
+++ b/docs/source/getting_started/verify.rst
@@ -6,7 +6,7 @@ Our SDK allows you to verify that a model satisfies the constraints of the meta-
 
 The verification logic is concentrated in the module :py:mod:`aas_core3_rc02.verification`, and all it takes is a call to :py:func:`aas_core3_rc02.verification.verify` function.
 The function :py:func:`aas_core3_rc02.verification.verify` will check that constraints in the given model element are satisfied, including the recursion into children elements.
-The function returns an iterator of :py:class:`aas_core3_rc02.verification.Error`'s, which you can use to for further processing (*e.g.*, report to the user).
+The function returns an iterator of :py:class:`aas_core3_rc02.verification.Error`'s, which you can use for further processing (*e.g.*, report to the user).
 
 Here is a short example snippet:
 


### PR DESCRIPTION
We reviewed the docs once more while writing the docs for the TypeScript SDK. The fixes are bundled in this patch.