### PR TITLE
Fix minor typo in Python jsonization

### DIFF
--- a/aas_core3_rc02/jsonization.py
+++ b/aas_core3_rc02/jsonization.py
@@ -54,7 +54,7 @@ class PropertySegment:
 class IndexSegment:
     """Represent an index access on a path to the erroneous value."""
 
-    #: Containers that contains the item
+    #: Container that contains the item
     container: Final[Iterable[Any]]
 
     #: Index of the item


### PR DESCRIPTION
We fix the error where we mistakenly wrote "Containers" instead of a single "container" in ``IndexSegment``. The ``IndexSegment`` refers to an array so there can not be multiple containers.

This patch corresponds to [aas-core-codegen 4c6e3a64].

[aas-core-codegen 4c6e3a64]: https://github.com/aas-core-works/aas-core-codegen/commit/4c6e3a64