### PR TITLE
Deprecate for Python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.11']
 
     steps:
       - uses: actions/checkout@master

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
We can not test against Python 3.6 as it seems that GitHub workflows do not support them any more. Hence, we do not "officially" support it anymore.