### PR TITLE
Fix verifications to check for falsy matches

### DIFF
--- a/aas_core3_rc02/verification.py
+++ b/aas_core3_rc02/verification.py
@@ -180,7 +180,7 @@ def is_xs_date_time_stamp_utc(value: str) -> bool:
     Check that :paramref:`value` is a ``xs:dateTimeStamp`` with
     the time zone set to UTC.
     """
-    if matches_xs_date_time_stamp_utc(value) is False:
+    if not matches_xs_date_time_stamp_utc(value):
         return False
 
     date, _ = value.split("T")
@@ -1349,7 +1349,7 @@ def is_xs_double(value: str) -> bool:
     # ``float(.)`` is too permissive. For example,
     # it accepts "nan" although only "NaN" is valid.
     # See: https://www.w3.org/TR/xmlschema-2/#double
-    if matches_xs_double(value) is False:
+    if not matches_xs_double(value):
         return False
 
     converted = float(value)
@@ -1374,7 +1374,7 @@ def is_xs_float(value: str) -> bool:
     # ``float(.)`` is too permissive. For example,
     # it accepts "nan" although only "NaN" is valid.
     # See: https://www.w3.org/TR/xmlschema-2/#double
-    if matches_xs_float(value) is False:
+    if not matches_xs_float(value):
         return False
 
     converted = float(value)
@@ -1404,7 +1404,7 @@ def is_xs_float(value: str) -> bool:
 
 def is_xs_g_month_day(value: str) -> bool:
     """Check that :paramref:`value` is a valid ``xs:gMonthDay``."""
-    if matches_xs_g_month_day(value) is False:
+    if not matches_xs_g_month_day(value):
         return False
 
     month = int(value[2:4])
@@ -1416,7 +1416,7 @@ def is_xs_g_month_day(value: str) -> bool:
 
 def is_xs_long(value: str) -> bool:
     """Check that :paramref:`value` is a valid ``xs:long``."""
-    if matches_xs_long(value) is False:
+    if not matches_xs_long(value):
         return False
 
     converted = int(value)
@@ -1425,7 +1425,7 @@ def is_xs_long(value: str) -> bool:
 
 def is_xs_int(value: str) -> bool:
     """Check that :paramref:`value` is a valid ``xs:int``."""
-    if matches_xs_int(value) is False:
+    if not matches_xs_int(value):
         return False
 
     converted = int(value)
@@ -1434,7 +1434,7 @@ def is_xs_int(value: str) -> bool:
 
 def is_xs_short(value: str) -> bool:
     """Check that :paramref:`value` is a valid ``xs:short``."""
-    if matches_xs_short(value) is False:
+    if not matches_xs_short(value):
         return False
 
     converted = int(value)
@@ -1443,7 +1443,7 @@ def is_xs_short(value: str) -> bool:
 
 def is_xs_byte(value: str) -> bool:
     """Check that :paramref:`value` is a valid ``xs:byte``."""
-    if matches_xs_byte(value) is False:
+    if not matches_xs_byte(value):
         return False
 
     converted = int(value)
@@ -1452,7 +1452,7 @@ def is_xs_byte(value: str) -> bool:
 
 def is_xs_unsigned_long(value: str) -> bool:
     """Check that :paramref:`value` is a valid ``xs:unsignedLong``."""
-    if matches_xs_unsigned_long(value) is False:
+    if not matches_xs_unsigned_long(value):
         return False
 
     converted = int(value)
@@ -1461,7 +1461,7 @@ def is_xs_unsigned_long(value: str) -> bool:
 
 def is_xs_unsigned_int(value: str) -> bool:
     """Check that :paramref:`value` is a valid ``xs:unsignedInt``."""
-    if matches_xs_unsigned_int(value) is False:
+    if not matches_xs_unsigned_int(value):
         return False
 
     converted = int(value)
@@ -1470,7 +1470,7 @@ def is_xs_unsigned_int(value: str) -> bool:
 
 def is_xs_unsigned_short(value: str) -> bool:
     """Check that :paramref:`value` is a valid ``xs:unsignedShort``."""
-    if matches_xs_unsigned_short(value) is False:
+    if not matches_xs_unsigned_short(value):
         return False
 
     converted = int(value)
@@ -1479,7 +1479,7 @@ def is_xs_unsigned_short(value: str) -> bool:
 
 def is_xs_unsigned_byte(value: str) -> bool:
     """Check that :paramref:`value` is a valid ``xs:unsignedByte``."""
-    if matches_xs_unsigned_byte(value) is False:
+    if not matches_xs_unsigned_byte(value):
         return False
 
     converted = int(value)


### PR DESCRIPTION
We compared against ``is False`` instead of using ``not`` operator. This is much less readable, and in cases where ``matches_*`` functions return non-boolean, can lead to bugs.

This patch fixes the issue by consistently using ``not`` operator.

This patch corresponds to [aas-core-codegen a6445b99].

[aas-core-codegen a6445b99]: https://github.com/aas-core-works/aas-core-codegen/commit/a6445b99