### PR TITLE
Release 1.0.0rc4

### DIFF
--- a/aas_core3_rc02/__init__.py
+++ b/aas_core3_rc02/__init__.py
@@ -1,7 +1,7 @@
 """Manipulate, verify and de/serialize Asset Administration Shells."""
 
 # Synchronize with __init__.py and changelog.rst!
-__version__ = "1.0.0rc3"
+__version__ = "1.0.0rc4"
 __author__ = "Marko Ristin"
 __copyright__ = (
     "2022 Zurich University of Applied Sciences, Institute of Mechatronic Systems (IMS)"

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,6 +2,15 @@
 Change Log
 **********
 
+1.0.0rc4 (2022-12-17)
+=====================
+Non-breaking changes:
+
+* Fix verifications to check for falsy matches (#25)
+* Fix ``is_xs_date*`` to match first (#24)
+* Deprecate for Python 3.6 (#23)
+* Minor fixes in the documentations (#22, #21, #20, #19, #18, #16)
+
 1.0.0rc3 (2022-11-02)
 =====================
 * Sync naming with the published schemas for V3RC02 (#13)

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open(os.path.join(here, "README.rst"), encoding="utf-8") as fid:
 setup(
     name="aas-core3.0rc02",
     # Synchronize with __init__.py and changelog.rst!
-    version="1.0.0rc3",
+    version="1.0.0rc4",
     description="Manipulate, verify and de/serialize Asset Administration Shells.",
     long_description=long_description,
     url="https://github.com/aas-core-works/aas-core3.0rc02-python",


### PR DESCRIPTION
Non-breaking changes:

* Fix verifications to check for falsy matches (#25)
* Fix ``is_xs_date*`` to match first (#24)
* Deprecate for Python 3.6 (#23)
* Minor fixes in the documentations (#22, #21, #20, #19, #18, #16)